### PR TITLE
docs: prepare release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ export default {
 };
 ```
 
-| Option                     | Platform      | Description                                                                                                                                 |
-| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `googleMapsApiKey`         | iOS + Android | Shared fallback when platform-specific keys are omitted.                                                                                    |
-| `iosGoogleMapsApiKey`      | iOS           | Injects `GoogleMapsIosApiKey` into `Info.plist` for `provider="google"`.                                                                    |
-| `androidGoogleMapsApiKey`  | Android       | Injects `com.google.android.geo.API_KEY` metadata.                                                                                          |
-| `locationPermission`       | iOS + Android | String sets `NSLocationWhenInUseUsageDescription` and adds `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION`. Pass `false` or omit to skip. |
-| `locationAlwaysPermission` | iOS + Android | String sets `NSLocationAlwaysAndWhenInUseUsageDescription` and adds `ACCESS_BACKGROUND_LOCATION`. Pass `false` or omit to skip.             |
+| Option                     | Platform      | Description                                                                                                                                                                                                                                       |
+| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `googleMapsApiKey`         | iOS + Android | Shared fallback when platform-specific keys are omitted.                                                                                                                                                                                          |
+| `iosGoogleMapsApiKey`      | iOS           | Injects `GoogleMapsIosApiKey` into `Info.plist` for `provider="google"`.                                                                                                                                                                          |
+| `androidGoogleMapsApiKey`  | Android       | Injects `com.google.android.geo.API_KEY` metadata.                                                                                                                                                                                                |
+| `locationPermission`       | iOS + Android | Foreground location message. Injects `NSLocationWhenInUseUsageDescription` plus `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION`. Pass `false` or omit to skip.                                                                                  |
+| `locationAlwaysPermission` | iOS + Android | Background location message. Injects `NSLocationAlwaysAndWhenInUseUsageDescription` plus `ACCESS_BACKGROUND_LOCATION`; also supplies foreground usage strings and permissions when `locationPermission` is omitted. Pass `false` or omit to skip. |
 
 After `expo prebuild`, native projects have the required keys and permissions without manual edits.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 Fast, typed maps for React Native, built on [Nitro Modules](https://nitro.margelo.com) and the New Architecture.
 
-![React Native](https://img.shields.io/badge/React%20Native-0.78%2B-61dafb)
-![Nitro Modules](https://img.shields.io/badge/Nitro%20Modules-0.35%2B-2563eb)
-![Platforms](https://img.shields.io/badge/platforms-iOS%20%7C%20Android-111827)
-![License](https://img.shields.io/badge/license-MIT-16a34a)
+[![npm version](https://img.shields.io/npm/v/react-native-nitro-maps.svg)](https://www.npmjs.com/package/react-native-nitro-maps)
+[![CI](https://github.com/gmi-software/react-native-nitro-maps/actions/workflows/ci.yml/badge.svg)](https://github.com/gmi-software/react-native-nitro-maps/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)
+![Expo Development Build](https://img.shields.io/badge/Expo-development%20build-000020.svg)
 
 Built with [Nitro Modules](https://nitro.margelo.com/) for high-performance native map rendering.
 
@@ -22,6 +23,7 @@ Built with [Nitro Modules](https://nitro.margelo.com/) for high-performance nati
 ## Table of contents
 
 - [Features](#features)
+- [Requirements](#requirements)
 - [Supported platforms](#supported-platforms)
 - [Installation](#installation)
 - [Quick start](#quick-start)
@@ -35,7 +37,7 @@ Built with [Nitro Modules](https://nitro.margelo.com/) for high-performance nati
 - [Documentation](#documentation)
 - [Common problems](#common-problems)
 - [Development](#development)
-- [Roadmap](#roadmap)
+- [What's next](#whats-next)
 
 ## Features
 
@@ -50,23 +52,28 @@ Built with [Nitro Modules](https://nitro.margelo.com/) for high-performance nati
 - **Expo friendly** - Config plugin for Google Maps API keys and location permissions.
 - **Tree-shakeable package** - ESM-only build with an explicit `exports` map.
 
-## Supported platforms
+## Requirements
 
-React Native Nitro Maps requires React Native `0.78+` with the New Architecture enabled.
+| Requirement               | Version / note                              |
+| ------------------------- | ------------------------------------------- |
+| React Native              | `0.78+`                                     |
+| React Native architecture | New Architecture enabled                    |
+| Nitro Modules             | `react-native-nitro-modules >=0.35.0`       |
+| iOS                       | `16.0+`                                     |
+| Android                   | `minSdkVersion 24+`                         |
+| Expo                      | Development build; Expo Go is not supported |
+
+Not supported today:
+
+- Custom React Native marker child views such as `<Marker><View /></Marker>`; use bitmap marker images instead.
+- `openstreetmap` and `mapbox` providers; the public provider type reserves these names for future native implementations.
+
+## Supported platforms
 
 | Platform | Default provider | Available providers |
 | -------- | ---------------- | ------------------- |
 | iOS      | `apple`          | `apple`, `google`   |
 | Android  | `google`         | `google`            |
-
-Planned providers are part of the public `MapProvider` type but do not render native maps yet:
-
-| Provider        | iOS       | Android     | Notes                           |
-| --------------- | --------- | ----------- | ------------------------------- |
-| `apple`         | Supported | Unsupported | Apple MapKit                    |
-| `google`        | Supported | Supported   | Google Maps SDK                 |
-| `openstreetmap` | Planned   | Planned     | No rendering implementation yet |
-| `mapbox`        | Planned   | Planned     | No rendering implementation yet |
 
 Unsupported explicit providers throw before a native map view is created.
 
@@ -338,26 +345,26 @@ On Google Maps providers, marker and cluster entering animations can reduce UI-t
 
 ## Capability matrix
 
-| Capability                 | `apple` iOS                                                 | `google` iOS                               | `google` Android                           | Future providers     |
-| -------------------------- | ----------------------------------------------------------- | ------------------------------------------ | ------------------------------------------ | -------------------- |
-| Region / camera            | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Camera animation           | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Visible region             | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Fit to coordinates         | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Map types                  | Standard, satellite, hybrid; terrain falls back to standard | Standard, satellite, hybrid, terrain       | Standard, satellite, hybrid, terrain       | Planned              |
-| Gestures                   | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| User location              | Supported; host app owns permission prompt                  | Supported; host app owns permission prompt | Supported; host app owns permission prompt | Planned              |
-| Compass                    | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Scale control              | Supported                                                   | Unsupported                                | Unsupported                                | Planned per provider |
-| Markers / overlays         | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Custom marker images       | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Marker callouts / dragging | Supported                                                   | Supported                                  | Supported                                  | Planned per provider |
-| Overlay press events       | Supported                                                   | Supported                                  | Supported                                  | Planned              |
-| Marker entering animation  | System + `fade`, `fade-scale`                               | System + `fade`; scale fallback            | System + `fade`; scale fallback            | Planned per provider |
-| Cluster entering animation | System + `fade`, `fade-scale`                               | System + `fade`; scale fallback            | System + `fade`; scale fallback            | Planned per provider |
-| Clustering                 | Supported                                                   | Supported                                  | Supported                                  | Planned per provider |
-| Custom styles              | Curated subset on iOS 16+                                   | Google Maps JSON styles                    | Google Maps JSON styles                    | Planned per provider |
-| Google Map ID              | Unsupported                                                 | Supported                                  | Supported                                  | Planned per provider |
+| Capability                 | `apple` iOS                                                 | `google` iOS                               | `google` Android                           |
+| -------------------------- | ----------------------------------------------------------- | ------------------------------------------ | ------------------------------------------ |
+| Region / camera            | Supported                                                   | Supported                                  | Supported                                  |
+| Camera animation           | Supported                                                   | Supported                                  | Supported                                  |
+| Visible region             | Supported                                                   | Supported                                  | Supported                                  |
+| Fit to coordinates         | Supported                                                   | Supported                                  | Supported                                  |
+| Map types                  | Standard, satellite, hybrid; terrain falls back to standard | Standard, satellite, hybrid, terrain       | Standard, satellite, hybrid, terrain       |
+| Gestures                   | Supported                                                   | Supported                                  | Supported                                  |
+| User location              | Supported; host app owns permission prompt                  | Supported; host app owns permission prompt | Supported; host app owns permission prompt |
+| Compass                    | Supported                                                   | Supported                                  | Supported                                  |
+| Scale control              | Supported                                                   | Unsupported                                | Unsupported                                |
+| Markers / overlays         | Supported                                                   | Supported                                  | Supported                                  |
+| Custom marker images       | Supported                                                   | Supported                                  | Supported                                  |
+| Marker callouts / dragging | Supported                                                   | Supported                                  | Supported                                  |
+| Overlay press events       | Supported                                                   | Supported                                  | Supported                                  |
+| Marker entering animation  | System + `fade`, `fade-scale`                               | System + `fade`; scale fallback            | System + `fade`; scale fallback            |
+| Cluster entering animation | System + `fade`, `fade-scale`                               | System + `fade`; scale fallback            | System + `fade`; scale fallback            |
+| Clustering                 | Supported                                                   | Supported                                  | Supported                                  |
+| Custom styles              | Curated subset on iOS 16+                                   | Google Maps JSON styles                    | Google Maps JSON styles                    |
+| Google Map ID              | Unsupported                                                 | Supported                                  | Supported                                  |
 
 ## Public API
 
@@ -433,7 +440,7 @@ See [example/.env.example](example/.env.example) for the supported environment v
 | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Map is blank when using Google Maps         | Add a Google Maps API key through the Expo config plugin, `GoogleMapsIosApiKey` in `Info.plist`, or `com.google.android.geo.API_KEY` in `AndroidManifest.xml`. |
 | New Architecture errors                     | Confirm React Native `0.78+`, New Architecture, and `react-native-nitro-modules` are installed, then rebuild the native app.                                   |
-| Provider throws before rendering            | Check the [supported platforms](#supported-platforms) table. `openstreetmap` and `mapbox` are typed for future support but do not render yet.                  |
+| Provider throws before rendering            | Check the [supported platforms](#supported-platforms) table. `openstreetmap` and `mapbox` are reserved for future support but do not render yet.               |
 | Expo Go does not load native maps           | Use a development build after `expo prebuild`; native Nitro modules are not available in Expo Go.                                                              |
 | Marker animations affect gesture smoothness | For very large marker sets, prefer clustering, shorter durations, or disable marker/cluster entering animations.                                               |
 
@@ -460,22 +467,9 @@ bun run example start
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
-## Roadmap
+## What's next
 
-See [docs/roadmap.md](docs/roadmap.md) for the full development plan.
-
-| Area                 | Status      | Description                                          |
-| -------------------- | ----------- | ---------------------------------------------------- |
-| Project skeleton     | Active      | Project structure, TypeScript types, package exports |
-| Nitro View           | Active      | Nitrogen codegen and native `MapView` HybridView     |
-| MapKit               | Active      | Apple MapKit integration on iOS                      |
-| Google Maps          | Active      | Google Maps SDK integration on iOS and Android       |
-| Overlays             | Active      | Markers, polylines, polygons, circles                |
-| Events & gestures    | Active      | Press, long-press, and region change callbacks       |
-| Clustering           | Active      | Marker clustering                                    |
-| Polish & release     | In progress | Performance work, docs, and v1.0 readiness           |
-| Additional providers | Planned     | OpenStreetMap and Mapbox provider implementations    |
-| Offline tile caching | Future      | Offline map tile support                             |
+The release surface focuses on Apple MapKit and Google Maps SDK providers. Follow-up work is tracked in [docs/roadmap.md](docs/roadmap.md), including additional providers, expanded migration docs, and offline tile support.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Built with [Nitro Modules](https://nitro.margelo.com/) for high-performance nati
 
 **Full documentation** lives in [`docs/`](docs). Start with [Expo setup](docs/expo-setup.md), [Architecture](docs/architecture.md), and [Roadmap](docs/roadmap.md).
 
-> **Status: Work in Progress**
->
-> Native rendering exists for Apple MapKit on iOS and Google Maps SDK on iOS and Android. Additional providers are planned.
-
 </div>
 
 ---

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "package": {
       "name": "react-native-nitro-maps",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "devDependencies": {
         "@expo/config-plugins": "~56.0.0",
         "@types/jest": "^29.5.14",

--- a/docs/expo-setup.md
+++ b/docs/expo-setup.md
@@ -39,13 +39,13 @@ module.exports = {
 
 ### Plugin options
 
-| Option                     | Type              | Default | Description                                                                                                                    |
-| -------------------------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `googleMapsApiKey`         | `string`          | —       | Shared fallback for iOS and Android when platform-specific keys are omitted.                                                   |
-| `iosGoogleMapsApiKey`      | `string`          | —       | Injects `GoogleMapsIosApiKey` into `Info.plist` for `provider="google"` on iOS.                                                |
-| `androidGoogleMapsApiKey`  | `string`          | —       | Injects `com.google.android.geo.API_KEY` meta-data on Android.                                                                 |
-| `locationPermission`       | `string \| false` | —       | When set to a string: iOS `NSLocationWhenInUseUsageDescription` + Android `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`. |
-| `locationAlwaysPermission` | `string \| false` | —       | When set to a string: iOS `NSLocationAlwaysAndWhenInUseUsageDescription` + Android `ACCESS_BACKGROUND_LOCATION`.               |
+| Option                     | Type              | Default | Description                                                                                                                                                                                                                     |
+| -------------------------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `googleMapsApiKey`         | `string`          | —       | Shared fallback for iOS and Android when platform-specific keys are omitted.                                                                                                                                                    |
+| `iosGoogleMapsApiKey`      | `string`          | —       | Injects `GoogleMapsIosApiKey` into `Info.plist` for `provider="google"` on iOS.                                                                                                                                                 |
+| `androidGoogleMapsApiKey`  | `string`          | —       | Injects `com.google.android.geo.API_KEY` meta-data on Android.                                                                                                                                                                  |
+| `locationPermission`       | `string \| false` | —       | Foreground location message. Injects iOS `NSLocationWhenInUseUsageDescription` plus Android `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`.                                                                                |
+| `locationAlwaysPermission` | `string \| false` | —       | Background location message. Injects iOS `NSLocationAlwaysAndWhenInUseUsageDescription` plus Android `ACCESS_BACKGROUND_LOCATION`; also supplies foreground usage strings and permissions when `locationPermission` is omitted. |
 
 Omitting Google Maps keys does not fail prebuild. iOS MapKit works without a key, but the iOS and Android Google Maps providers require their platform keys before they can render.
 
@@ -111,6 +111,6 @@ The example's `prebuild` script builds the plugin (`build:plugin`) before runnin
 | Symptom                                     | Fix                                                                                                                            |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | Blank Google map                            | Ensure `googleMapsApiKey` or the platform-specific Google Maps key is set, then run `expo prebuild` again.                     |
-| Location dot not showing                    | Set `locationPermission` in the plugin options and re-run prebuild.                                                            |
+| Location dot not showing                    | Set `locationPermission` or `locationAlwaysPermission` in the plugin options and re-run prebuild.                              |
 | Plugin not found                            | Confirm `react-native-nitro-maps` is installed and listed in `plugins`.                                                        |
 | `Cannot find module './plugin/build/index'` | Run `bun run build:plugin` in the package (or `bun run build` from the repo root) before prebuild when using a workspace link. |

--- a/docs/expo-setup.md
+++ b/docs/expo-setup.md
@@ -39,13 +39,15 @@ module.exports = {
 
 ### Plugin options
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `googleMapsApiKey` | `string` | — | Android: injects `com.google.android.geo.API_KEY` meta-data. iOS: no-op (MapKit needs no key; reserved for future Google Maps iOS support in [#2](https://github.com/gmi-software/react-native-nitro-maps/issues/2)). |
-| `locationPermission` | `string \| false` | — | When set to a string: iOS `NSLocationWhenInUseUsageDescription` + Android `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`. |
-| `locationAlwaysPermission` | `string \| false` | — | When set to a string: iOS `NSLocationAlwaysAndWhenInUseUsageDescription` + Android `ACCESS_BACKGROUND_LOCATION`. |
+| Option                     | Type              | Default | Description                                                                                                                    |
+| -------------------------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `googleMapsApiKey`         | `string`          | —       | Shared fallback for iOS and Android when platform-specific keys are omitted.                                                   |
+| `iosGoogleMapsApiKey`      | `string`          | —       | Injects `GoogleMapsIosApiKey` into `Info.plist` for `provider="google"` on iOS.                                                |
+| `androidGoogleMapsApiKey`  | `string`          | —       | Injects `com.google.android.geo.API_KEY` meta-data on Android.                                                                 |
+| `locationPermission`       | `string \| false` | —       | When set to a string: iOS `NSLocationWhenInUseUsageDescription` + Android `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`. |
+| `locationAlwaysPermission` | `string \| false` | —       | When set to a string: iOS `NSLocationAlwaysAndWhenInUseUsageDescription` + Android `ACCESS_BACKGROUND_LOCATION`.               |
 
-Omitting `googleMapsApiKey` does not fail prebuild. Android maps will not render until a key is provided (via the plugin or manually). iOS MapKit works without a key.
+Omitting Google Maps keys does not fail prebuild. iOS MapKit works without a key, but the iOS and Android Google Maps providers require their platform keys before they can render.
 
 ## Google Maps API key
 
@@ -83,8 +85,8 @@ expo prebuild --clean
 
 The plugin injects:
 
-- **Android:** `com.google.android.geo.API_KEY` meta-data (when `googleMapsApiKey` is set) and location permissions (when location options are set)
-- **iOS:** location usage description strings (when location options are set)
+- **Android:** `com.google.android.geo.API_KEY` meta-data (when `googleMapsApiKey` or `androidGoogleMapsApiKey` is set) and location permissions (when location options are set)
+- **iOS:** `GoogleMapsIosApiKey` (when `googleMapsApiKey` or `iosGoogleMapsApiKey` is set) and location usage description strings (when location options are set)
 
 ## Run
 
@@ -106,9 +108,9 @@ The example's `prebuild` script builds the plugin (`build:plugin`) before runnin
 
 ## Troubleshooting
 
-| Symptom | Fix |
-| --- | --- |
-| Blank map on Android | Ensure `googleMapsApiKey` is set and `expo prebuild` was run after adding the plugin. |
-| Location dot not showing | Set `locationPermission` in the plugin options and re-run prebuild. |
-| Plugin not found | Confirm `react-native-nitro-maps` is installed and listed in `plugins`. |
+| Symptom                                     | Fix                                                                                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Blank Google map                            | Ensure `googleMapsApiKey` or the platform-specific Google Maps key is set, then run `expo prebuild` again.                     |
+| Location dot not showing                    | Set `locationPermission` in the plugin options and re-run prebuild.                                                            |
+| Plugin not found                            | Confirm `react-native-nitro-maps` is installed and listed in `plugins`.                                                        |
 | `Cannot find module './plugin/build/index'` | Run `bun run build:plugin` in the package (or `bun run build` from the repo root) before prebuild when using a workspace link. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,11 @@
 # Roadmap
 
-## Phase 1: Project skeleton (current)
+## Phase 1: Project skeleton
 
 - [x] Monorepo structure with Bun workspaces
 - [x] TypeScript types and interfaces
-- [x] Placeholder React components
-- [x] Nitro config and placeholder spec
+- [x] React component exports
+- [x] Nitro config and initial HybridView spec
 - [x] ESM build pipeline (react-native-builder-bob)
 - [x] ESLint, Prettier, GitHub Actions CI
 - [x] Expo example app
@@ -70,8 +70,10 @@ Delivered incrementally during Phases 3–5; polished for platform consistency i
 
 - [x] Multi-provider `MapView` architecture
 - [x] Google Maps provider on iOS
-- [ ] Performance profiling and optimization
-- [ ] Comprehensive documentation site
+- [x] Public README and package metadata
+- [x] Expo setup documentation
+- [x] CI quality checks
+- [ ] Release performance benchmark pass
 - [ ] Migration guide from react-native-maps
 - [ ] npm publish (v1.0.0)
 - [ ] GitHub release with changelog

--- a/package/package.json
+++ b/package/package.json
@@ -60,7 +60,7 @@
     "url": "https://github.com/gmi-software/react-native-nitro-maps/issues"
   },
   "homepage": "https://github.com/gmi-software/react-native-nitro-maps#readme",
-  "author": "GMI Software",
+  "author": "gmi.software",
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-maps",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "High-performance maps for React Native built on Nitro Modules and the New Architecture",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/index.d.ts",
@@ -54,13 +54,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/YOUR_GITHUB/react-native-nitro-maps.git"
+    "url": "https://github.com/gmi-software/react-native-nitro-maps.git"
   },
   "bugs": {
-    "url": "https://github.com/YOUR_GITHUB/react-native-nitro-maps/issues"
+    "url": "https://github.com/gmi-software/react-native-nitro-maps/issues"
   },
-  "homepage": "https://github.com/YOUR_GITHUB/react-native-nitro-maps#readme",
-  "author": "YOUR_NAME",
+  "homepage": "https://github.com/gmi-software/react-native-nitro-maps#readme",
+  "author": "GMI Software",
   "license": "MIT",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary
- remove the Work in Progress callout from the README hero section
- replace placeholder package metadata with real GMI repository, issue, homepage, author, and v1.0.0 version data
- make README release-oriented: real badges, requirements, current provider matrix, and a lighter what's-next section
- update Expo setup docs for iOS/Android Google Maps API key support
- refresh roadmap wording so release readiness items are explicit without exposing placeholder language

## Validation
- ./node_modules/.bin/prettier --check README.md docs/expo-setup.md docs/roadmap.md package/package.json
- git diff --check
- bun run --filter react-native-nitro-maps typecheck
- bun run --filter react-native-nitro-maps typecheck:provider-types
- bun run --filter react-native-nitro-maps build