### PR TITLE
fix: first time build fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "example"
   ],
   "scripts": {
-    "prebuild": "bun run nitrogen",
     "build": "bun run --filter react-native-better-maps build",
     "lint": "eslint .",
     "typecheck": "bun run --filter react-native-better-maps typecheck",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "example"
   ],
   "scripts": {
+    "prebuild": "bun run nitrogen",
     "build": "bun run --filter react-native-better-maps build",
     "lint": "eslint .",
     "typecheck": "bun run --filter react-native-better-maps typecheck",

--- a/package/package.json
+++ b/package/package.json
@@ -34,6 +34,7 @@
     "!**/__mocks__"
   ],
   "scripts": {
+    "prebuild": "bun run nitrogen",
     "build": "bob build && bun run build:plugin",
     "clean:plugin": "rm -rf plugin/build",
     "build:plugin": "bun run clean:plugin && tsc --project tsconfig.plugin.json",


### PR DESCRIPTION
# Summary

Adds a pre-build step to generate Nitrogen output before the package build runs.

# Why

bun run build can fail on a clean checkout because Bob’s TypeScript declaration build imports generated Nitrogen output from:

`../../nitrogen/generated/shared/json/MapViewConfig.json`

If bun run nitrogen has not been run first, that file is missing and the build fails with a TS error.

This change makes the documented build command work reliably for clean environments.

# Testing
```
git clean -fdx
bun install
bun run build
```