### PR TITLE
fix(android): align SDK versions with nitro-modules prefab

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -16,6 +16,14 @@ def reactNativeArchitectures() {
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+def getExtOrDefault(name) {
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties["NitroMaps_" + name]
+}
+
+def getExtOrIntegerDefault(name) {
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["NitroMaps_" + name]).toInteger()
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply from: '../nitrogen/generated/android/NitroMaps+autolinking.gradle'
@@ -23,11 +31,13 @@ apply plugin: 'com.facebook.react'
 
 android {
     namespace 'com.margelo.nitro.nitromaps'
-    compileSdkVersion 35
+
+    ndkVersion getExtOrDefault("ndkVersion")
+    compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
     defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 35
+        minSdkVersion getExtOrIntegerDefault("minSdkVersion")
+        targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
 
         externalNativeBuild {
             cmake {

--- a/package/android/gradle.properties
+++ b/package/android/gradle.properties
@@ -1,0 +1,4 @@
+NitroMaps_minSdkVersion=24
+NitroMaps_targetSdkVersion=35
+NitroMaps_compileSdkVersion=35
+NitroMaps_ndkVersion=27.1.12297006

--- a/package/package.json
+++ b/package/package.json
@@ -25,6 +25,7 @@
     "android/CMakeLists.txt",
     "android/README.md",
     "android/build.gradle",
+    "android/gradle.properties",
     "android/src",
     "cpp",
     "nitro.json",


### PR DESCRIPTION
## Summary

- Replace hardcoded Android SDK versions in `package/android/build.gradle` with `getExtOrDefault` / `getExtOrIntegerDefault` helpers (Nitro template pattern)
- Add `package/android/gradle.properties` with `NitroMaps_*` fallbacks when the host app does not define `rootProject.ext`
- Include `gradle.properties` in the published npm package

Fixes #40

## Why

`minSdkVersion 24` was hardcoded while `react-native-nitro-modules` inherits the host app's `minSdkVersion`. In apps targeting API 26+, Prefab/CMake fails with `CXX1214`.

## Test plan

- [ ] Android build in example app with default Expo/RN SDK settings
- [ ] Android build in a host app with `minSdkVersion 26+`
- [ ] Confirm no `CXX1214` Prefab mismatch during native build