### PR TITLE
fix(ios): remove main.sync from HybridMapView and async camera APIs

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,4 @@
 import {
-  forwardRef,
   memo,
   useCallback,
   useEffect,
@@ -7,6 +6,7 @@ import {
   useRef,
   useState,
   type ReactNode,
+  type Ref,
 } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import {
@@ -485,6 +485,7 @@ const ScenarioDock = memo(function ScenarioDock({
 });
 
 type MapSceneProps = {
+  ref?: Ref<MapViewRef>;
   scenario: MapScenario;
   provider: SupportedExampleProvider;
   mapType: MapType;
@@ -500,25 +501,22 @@ type MapSceneProps = {
   onLongPress: (coordinate: Coordinate) => void;
 };
 
-const MapScene = memo(
-  forwardRef<MapViewRef, MapSceneProps>(function MapScene(
-    {
-      scenario,
-      provider,
-      mapType,
-      mapPadding,
-      animationOption,
-      onMapReady,
-      onClusterPress,
-      onMarkerPress,
-      onMarkerDragEnd,
-      onOverlayPress,
-      onPress,
-      onPoiPress,
-      onLongPress,
-    },
-    ref,
-  ) {
+const MapScene = memo(function MapScene({
+  ref,
+  scenario,
+  provider,
+  mapType,
+  mapPadding,
+  animationOption,
+  onMapReady,
+  onClusterPress,
+  onMarkerPress,
+  onMarkerDragEnd,
+  onOverlayPress,
+  onPress,
+  onPoiPress,
+  onLongPress,
+}: MapSceneProps) {
     const commonMapProps = {
       style: styles.map,
       mapType,
@@ -569,8 +567,7 @@ const MapScene = memo(
         provider="google"
       />
     );
-  }),
-);
+});
 
 type StatusHeaderProps = {
   status: string;

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -668,29 +668,35 @@ export default function App() {
   );
 
   const handleAnimateCamera = useCallback(() => {
-    mapRef.current?.animateCamera(
-      {
-        center: {
-          latitude: scenario.region.latitude,
-          longitude: scenario.region.longitude,
+    mapRef.current
+      ?.animateCamera(
+        {
+          center: {
+            latitude: scenario.region.latitude,
+            longitude: scenario.region.longitude,
+          },
+          zoom: 13,
+          heading: 0,
+          pitch: 0,
         },
-        zoom: 13,
-        heading: 0,
-        pitch: 0,
-      },
-      1,
-    );
+        1,
+      )
+      ?.catch(() => {});
   }, [scenario]);
 
   const handleGetCamera = useCallback(async () => {
-    const camera = await mapRef.current?.getCamera();
-    if (camera == null) {
-      return;
-    }
+    try {
+      const camera = await mapRef.current?.getCamera();
+      if (camera == null) {
+        return;
+      }
 
-    setStatus(
-      `zoom ${camera.zoom?.toFixed(1) ?? '?'} · ${camera.center.latitude.toFixed(4)}, ${camera.center.longitude.toFixed(4)}`,
-    );
+      setStatus(
+        `zoom ${camera.zoom?.toFixed(1) ?? '?'} · ${camera.center.latitude.toFixed(4)}, ${camera.center.longitude.toFixed(4)}`,
+      );
+    } catch {
+      // Map unmounted or native call failed — ignore.
+    }
   }, []);
 
   const cycleMapType = useCallback(() => {
@@ -785,11 +791,13 @@ export default function App() {
       scenario.advanced?.fitToCoordinatesOnReady &&
       scenario.markers != null
     ) {
-      mapRef.current?.fitToCoordinates(
-        scenario.markers.map((marker) => marker.coordinate),
-        mapPadding,
-        true,
-      );
+      mapRef.current
+        ?.fitToCoordinates(
+          scenario.markers.map((marker) => marker.coordinate),
+          mapPadding,
+          true,
+        )
+        ?.catch(() => {});
     }
   }, [scenario, mapPadding]);
 

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/HybridMapView.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/HybridMapView.kt
@@ -271,12 +271,14 @@ class HybridMapView(private val context: ThemedReactContext) :
 
   override fun fetchCamera(): Promise<Camera> = currentAdapter().fetchCamera()
 
-  override fun applyCamera(camera: Camera) {
+  override fun applyCamera(camera: Camera): Promise<Unit> {
     currentAdapter().applyCamera(camera)
+    return Promise.resolved(Unit)
   }
 
-  override fun animateCamera(camera: Camera, duration: Double?) {
+  override fun animateCamera(camera: Camera, duration: Double?): Promise<Unit> {
     currentAdapter().animateCamera(camera, duration)
+    return Promise.resolved(Unit)
   }
 
   override fun getVisibleRegion(): Promise<VisibleRegion> = currentAdapter().getVisibleRegion()
@@ -285,8 +287,9 @@ class HybridMapView(private val context: ThemedReactContext) :
     coordinates: Array<Coordinate>,
     padding: EdgePadding?,
     animated: Boolean?,
-  ) {
+  ): Promise<Unit> {
     currentAdapter().fitToCoordinates(coordinates, padding, animated)
+    return Promise.resolved(Unit)
   }
 
   override fun prepareForRecycle() {

--- a/package/ios/HybridMapView.swift
+++ b/package/ios/HybridMapView.swift
@@ -48,10 +48,14 @@ final class HybridMapView: HybridMapViewSpec {
   }()
 
   var provider: MapProvider? {
-    get { onMain { _provider } }
+    get { _provider }
     set {
       let nextProvider = newValue ?? .apple
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         guard nextProvider != _provider || adapter == nil else {
           return
         }
@@ -63,9 +67,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var mapType: MapType {
-    get { onMain { _mapType } }
+    get { _mapType }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _mapType = newValue
         adapter?.mapType = newValue
       }
@@ -73,9 +81,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var region: Region? {
-    get { onMain { _region } }
+    get { _region }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _region = newValue
         adapter?.region = newValue
       }
@@ -83,9 +95,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var camera: Camera? {
-    get { onMain { _camera } }
+    get { _camera }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _camera = newValue
         adapter?.camera = newValue
       }
@@ -93,9 +109,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var scrollEnabled: Bool? {
-    get { onMain { _scrollEnabled } }
+    get { _scrollEnabled }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _scrollEnabled = newValue
         adapter?.scrollEnabled = newValue
       }
@@ -103,9 +123,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var zoomEnabled: Bool? {
-    get { onMain { _zoomEnabled } }
+    get { _zoomEnabled }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _zoomEnabled = newValue
         adapter?.zoomEnabled = newValue
       }
@@ -113,9 +137,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var rotateEnabled: Bool? {
-    get { onMain { _rotateEnabled } }
+    get { _rotateEnabled }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _rotateEnabled = newValue
         adapter?.rotateEnabled = newValue
       }
@@ -123,9 +151,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var pitchEnabled: Bool? {
-    get { onMain { _pitchEnabled } }
+    get { _pitchEnabled }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _pitchEnabled = newValue
         adapter?.pitchEnabled = newValue
       }
@@ -133,9 +165,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var showsUserLocation: Bool? {
-    get { onMain { _showsUserLocation } }
+    get { _showsUserLocation }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _showsUserLocation = newValue
         adapter?.showsUserLocation = newValue
       }
@@ -143,9 +179,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var followsUserLocation: Bool? {
-    get { onMain { _followsUserLocation } }
+    get { _followsUserLocation }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _followsUserLocation = newValue
         adapter?.followsUserLocation = newValue
       }
@@ -153,9 +193,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var showsCompass: Bool? {
-    get { onMain { _showsCompass } }
+    get { _showsCompass }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _showsCompass = newValue
         adapter?.showsCompass = newValue
       }
@@ -163,9 +207,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var showsScale: Bool? {
-    get { onMain { _showsScale } }
+    get { _showsScale }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _showsScale = newValue
         adapter?.showsScale = newValue
       }
@@ -173,9 +221,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var customMapStyle: String? {
-    get { onMain { _customMapStyle } }
+    get { _customMapStyle }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _customMapStyle = newValue
         adapter?.customMapStyle = newValue
       }
@@ -183,9 +235,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var googleMapId: String? {
-    get { onMain { _googleMapId } }
+    get { _googleMapId }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         guard _googleMapId != newValue else {
           return
         }
@@ -199,9 +255,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var clusteringEnabled: Bool? {
-    get { onMain { _clusteringEnabled } }
+    get { _clusteringEnabled }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _clusteringEnabled = newValue
         adapter?.clusteringEnabled = newValue
       }
@@ -209,9 +269,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var mapPadding: EdgePadding? {
-    get { onMain { _mapPadding } }
+    get { _mapPadding }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _mapPadding = newValue
         adapter?.mapPadding = newValue
       }
@@ -219,9 +283,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var markerEnteringAnimation: OverlayEnteringAnimationDescriptor? {
-    get { onMain { _markerEnteringAnimation } }
+    get { _markerEnteringAnimation }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _markerEnteringAnimation = newValue
         adapter?.markerEnteringAnimation = newValue
       }
@@ -229,9 +297,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var clusterEnteringAnimation: OverlayEnteringAnimationDescriptor? {
-    get { onMain { _clusterEnteringAnimation } }
+    get { _clusterEnteringAnimation }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _clusterEnteringAnimation = newValue
         adapter?.clusterEnteringAnimation = newValue
       }
@@ -239,9 +311,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onRegionChange: ((Region) -> Void)? {
-    get { onMain { _onRegionChange } }
+    get { _onRegionChange }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onRegionChange = newValue
         adapter?.onRegionChange = newValue
       }
@@ -249,9 +325,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onRegionChangeComplete: ((Region) -> Void)? {
-    get { onMain { _onRegionChangeComplete } }
+    get { _onRegionChangeComplete }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onRegionChangeComplete = newValue
         adapter?.onRegionChangeComplete = newValue
       }
@@ -259,9 +339,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onMapReady: (() -> Void)? {
-    get { onMain { _onMapReady } }
+    get { _onMapReady }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onMapReady = newValue
         adapter?.onMapReady = newValue
       }
@@ -269,9 +353,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onPress: ((Coordinate) -> Void)? {
-    get { onMain { _onPress } }
+    get { _onPress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onPress = newValue
         adapter?.onPress = newValue
       }
@@ -279,9 +367,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onPoiPress: ((NativePoiPressEvent) -> Void)? {
-    get { onMain { _onPoiPress } }
+    get { _onPoiPress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onPoiPress = newValue
         adapter?.onPoiPress = newValue
       }
@@ -289,9 +381,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onLongPress: ((Coordinate) -> Void)? {
-    get { onMain { _onLongPress } }
+    get { _onLongPress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onLongPress = newValue
         adapter?.onLongPress = newValue
       }
@@ -299,9 +395,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var markers: [MarkerDescriptor]? {
-    get { onMain { _markers } }
+    get { _markers }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _markers = newValue
         adapter?.markers = newValue
       }
@@ -309,9 +409,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var polylines: [PolylineDescriptor]? {
-    get { onMain { _polylines } }
+    get { _polylines }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _polylines = newValue
         adapter?.polylines = newValue
       }
@@ -319,9 +423,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var polygons: [PolygonDescriptor]? {
-    get { onMain { _polygons } }
+    get { _polygons }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _polygons = newValue
         adapter?.polygons = newValue
       }
@@ -329,9 +437,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var circles: [CircleDescriptor]? {
-    get { onMain { _circles } }
+    get { _circles }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _circles = newValue
         adapter?.circles = newValue
       }
@@ -339,9 +451,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onMarkerPress: ((String) -> Void)? {
-    get { onMain { _onMarkerPress } }
+    get { _onMarkerPress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onMarkerPress = newValue
         adapter?.onMarkerPress = newValue
       }
@@ -349,9 +465,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onMarkerDragEnd: ((String, Coordinate) -> Void)? {
-    get { onMain { _onMarkerDragEnd } }
+    get { _onMarkerDragEnd }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onMarkerDragEnd = newValue
         adapter?.onMarkerDragEnd = newValue
       }
@@ -359,9 +479,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onPolylinePress: ((String) -> Void)? {
-    get { onMain { _onPolylinePress } }
+    get { _onPolylinePress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onPolylinePress = newValue
         adapter?.onPolylinePress = newValue
       }
@@ -369,9 +493,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onPolygonPress: ((String) -> Void)? {
-    get { onMain { _onPolygonPress } }
+    get { _onPolygonPress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onPolygonPress = newValue
         adapter?.onPolygonPress = newValue
       }
@@ -379,9 +507,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onCirclePress: ((String) -> Void)? {
-    get { onMain { _onCirclePress } }
+    get { _onCirclePress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onCirclePress = newValue
         adapter?.onCirclePress = newValue
       }
@@ -389,9 +521,13 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   var onClusterPress: (([String], Coordinate) -> Void)? {
-    get { onMain { _onClusterPress } }
+    get { _onClusterPress }
     set {
-      onMain {
+      runOnMain { [weak self] in
+        guard let self else {
+          return
+        }
+
         _onClusterPress = newValue
         adapter?.onClusterPress = newValue
       }
@@ -402,16 +538,13 @@ final class HybridMapView: HybridMapViewSpec {
     promiseOnMain { try $0.fetchCamera() }
   }
 
-  func applyCamera(camera: Camera) throws {
-    let lifecycle = currentLifecycleSnapshot()
-    try onMain { try currentAdapter(matching: lifecycle).applyCamera(camera: camera) }
+  func applyCamera(camera: Camera) throws -> Promise<Void> {
+    promiseOnMainVoid { try $0.applyCamera(camera: camera) }
   }
 
-  func animateCamera(camera: Camera, duration: Double?) throws {
-    let lifecycle = currentLifecycleSnapshot()
-    try onMain {
-      try currentAdapter(matching: lifecycle)
-        .animateCamera(camera: camera, duration: duration)
+  func animateCamera(camera: Camera, duration: Double?) throws -> Promise<Void> {
+    promiseOnMainVoid {
+      try $0.animateCamera(camera: camera, duration: duration)
     }
   }
 
@@ -423,10 +556,9 @@ final class HybridMapView: HybridMapViewSpec {
     coordinates: [Coordinate],
     padding: EdgePadding?,
     animated: Bool?
-  ) throws {
-    let lifecycle = currentLifecycleSnapshot()
-    try onMain {
-      try currentAdapter(matching: lifecycle).fitToCoordinates(
+  ) throws -> Promise<Void> {
+    promiseOnMainVoid {
+      try $0.fitToCoordinates(
         coordinates: coordinates,
         padding: padding,
         animated: animated
@@ -435,13 +567,17 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   func afterUpdate() {
-    onMain {
-      activateLifecycle()
+    runOnMain { [weak self] in
+      self?.activateLifecycle()
     }
   }
 
   func prepareForRecycle() {
-    onMain {
+    runOnMain { [weak self] in
+      guard let self else {
+        return
+      }
+
       recycleLifecycle()
       adapter?.prepareForRecycle()
       adapter?.contentView.removeFromSuperview()
@@ -616,12 +752,41 @@ final class HybridMapView: HybridMapViewSpec {
     adapter.onClusterPress = _onClusterPress
   }
 
-  private func onMain<T>(_ work: () throws -> T) rethrows -> T {
+  private func runOnMain(_ work: @escaping () -> Void) {
     if Thread.isMainThread {
-      return try work()
+      work()
+    } else {
+      DispatchQueue.main.async(execute: work)
+    }
+  }
+
+  private func promiseOnMainVoid(
+    _ work: @escaping (MapProviderAdapter) throws -> Void
+  ) -> Promise<Void> {
+    let promise = Promise<Void>()
+    let lifecycle = currentLifecycleSnapshot()
+    let run = { [weak self] in
+      guard let self else {
+        promise.reject(withError: Self.mapViewNotMountedError())
+        return
+      }
+
+      do {
+        let adapter = try self.currentAdapter(matching: lifecycle)
+        try work(adapter)
+        promise.resolve(withResult: ())
+      } catch {
+        promise.reject(withError: error)
+      }
     }
 
-    return try DispatchQueue.main.sync(execute: work)
+    if Thread.isMainThread {
+      run()
+    } else {
+      DispatchQueue.main.async(execute: run)
+    }
+
+    return promise
   }
 
   private func promiseOnMain<T>(

--- a/package/ios/HybridMapView.swift
+++ b/package/ios/HybridMapView.swift
@@ -4,51 +4,18 @@ import UIKit
 final class HybridMapView: HybridMapViewSpec {
   private let containerView = UIView()
   private let lifecycleLock = NSLock()
+  private let stateLock = NSLock()
   private var adapter: MapProviderAdapter?
   private var lifecycleGeneration: UInt64 = 0
   private var isRecycled = false
-
-  private var _provider: MapProvider = .apple
-  private var _mapType: MapType = .standard
-  private var _region: Region?
-  private var _camera: Camera?
-  private var _scrollEnabled: Bool?
-  private var _zoomEnabled: Bool?
-  private var _rotateEnabled: Bool?
-  private var _pitchEnabled: Bool?
-  private var _showsUserLocation: Bool?
-  private var _followsUserLocation: Bool?
-  private var _showsCompass: Bool?
-  private var _showsScale: Bool?
-  private var _customMapStyle: String?
-  private var _googleMapId: String?
-  private var _clusteringEnabled: Bool?
-  private var _mapPadding: EdgePadding?
-  private var _markerEnteringAnimation: OverlayEnteringAnimationDescriptor?
-  private var _clusterEnteringAnimation: OverlayEnteringAnimationDescriptor?
-  private var _onRegionChange: ((Region) -> Void)?
-  private var _onRegionChangeComplete: ((Region) -> Void)?
-  private var _onMapReady: (() -> Void)?
-  private var _onPress: ((Coordinate) -> Void)?
-  private var _onPoiPress: ((NativePoiPressEvent) -> Void)?
-  private var _onLongPress: ((Coordinate) -> Void)?
-  private var _markers: [MarkerDescriptor]?
-  private var _polylines: [PolylineDescriptor]?
-  private var _polygons: [PolygonDescriptor]?
-  private var _circles: [CircleDescriptor]?
-  private var _onMarkerPress: ((String) -> Void)?
-  private var _onMarkerDragEnd: ((String, Coordinate) -> Void)?
-  private var _onPolylinePress: ((String) -> Void)?
-  private var _onPolygonPress: ((String) -> Void)?
-  private var _onCirclePress: ((String) -> Void)?
-  private var _onClusterPress: (([String], Coordinate) -> Void)?
+  private var _state = MapViewState()
 
   lazy var view: UIView = {
     containerView
   }()
 
   var provider: MapProvider? {
-    get { _provider }
+    get { getBacked(\.provider) }
     set {
       let nextProvider = newValue ?? .apple
       runOnMain { [weak self] in
@@ -56,482 +23,229 @@ final class HybridMapView: HybridMapViewSpec {
           return
         }
 
-        guard nextProvider != _provider || adapter == nil else {
+        let shouldInstall = withStateLock { () -> Bool in
+          guard nextProvider != self._state.provider || self.adapter == nil else {
+            return false
+          }
+
+          self._state.provider = nextProvider
+          return true
+        }
+
+        guard shouldInstall else {
           return
         }
 
-        _provider = nextProvider
         installAdapter(for: nextProvider)
       }
     }
   }
 
   var mapType: MapType {
-    get { _mapType }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _mapType = newValue
-        adapter?.mapType = newValue
-      }
-    }
+    get { getBacked(\.mapType) }
+    set { setBackedOnMain(newValue, store: \.mapType) { $0.mapType = $1 } }
   }
 
   var region: Region? {
-    get { _region }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _region = newValue
-        adapter?.region = newValue
-      }
-    }
+    get { getBacked(\.region) }
+    set { setBackedOnMain(newValue, store: \.region) { $0.region = $1 } }
   }
 
   var camera: Camera? {
-    get { _camera }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _camera = newValue
-        adapter?.camera = newValue
-      }
-    }
+    get { getBacked(\.camera) }
+    set { setBackedOnMain(newValue, store: \.camera) { $0.camera = $1 } }
   }
 
   var scrollEnabled: Bool? {
-    get { _scrollEnabled }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _scrollEnabled = newValue
-        adapter?.scrollEnabled = newValue
-      }
-    }
+    get { getBacked(\.scrollEnabled) }
+    set { setBackedOnMain(newValue, store: \.scrollEnabled) { $0.scrollEnabled = $1 } }
   }
 
   var zoomEnabled: Bool? {
-    get { _zoomEnabled }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _zoomEnabled = newValue
-        adapter?.zoomEnabled = newValue
-      }
-    }
+    get { getBacked(\.zoomEnabled) }
+    set { setBackedOnMain(newValue, store: \.zoomEnabled) { $0.zoomEnabled = $1 } }
   }
 
   var rotateEnabled: Bool? {
-    get { _rotateEnabled }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _rotateEnabled = newValue
-        adapter?.rotateEnabled = newValue
-      }
-    }
+    get { getBacked(\.rotateEnabled) }
+    set { setBackedOnMain(newValue, store: \.rotateEnabled) { $0.rotateEnabled = $1 } }
   }
 
   var pitchEnabled: Bool? {
-    get { _pitchEnabled }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _pitchEnabled = newValue
-        adapter?.pitchEnabled = newValue
-      }
-    }
+    get { getBacked(\.pitchEnabled) }
+    set { setBackedOnMain(newValue, store: \.pitchEnabled) { $0.pitchEnabled = $1 } }
   }
 
   var showsUserLocation: Bool? {
-    get { _showsUserLocation }
+    get { getBacked(\.showsUserLocation) }
     set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _showsUserLocation = newValue
-        adapter?.showsUserLocation = newValue
-      }
+      setBackedOnMain(newValue, store: \.showsUserLocation) { $0.showsUserLocation = $1 }
     }
   }
 
   var followsUserLocation: Bool? {
-    get { _followsUserLocation }
+    get { getBacked(\.followsUserLocation) }
     set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _followsUserLocation = newValue
-        adapter?.followsUserLocation = newValue
-      }
+      setBackedOnMain(newValue, store: \.followsUserLocation) { $0.followsUserLocation = $1 }
     }
   }
 
   var showsCompass: Bool? {
-    get { _showsCompass }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _showsCompass = newValue
-        adapter?.showsCompass = newValue
-      }
-    }
+    get { getBacked(\.showsCompass) }
+    set { setBackedOnMain(newValue, store: \.showsCompass) { $0.showsCompass = $1 } }
   }
 
   var showsScale: Bool? {
-    get { _showsScale }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _showsScale = newValue
-        adapter?.showsScale = newValue
-      }
-    }
+    get { getBacked(\.showsScale) }
+    set { setBackedOnMain(newValue, store: \.showsScale) { $0.showsScale = $1 } }
   }
 
   var customMapStyle: String? {
-    get { _customMapStyle }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _customMapStyle = newValue
-        adapter?.customMapStyle = newValue
-      }
-    }
+    get { getBacked(\.customMapStyle) }
+    set { setBackedOnMain(newValue, store: \.customMapStyle) { $0.customMapStyle = $1 } }
   }
 
   var googleMapId: String? {
-    get { _googleMapId }
+    get { getBacked(\.googleMapId) }
     set {
+      let nextGoogleMapId = newValue
       runOnMain { [weak self] in
         guard let self else {
           return
         }
 
-        guard _googleMapId != newValue else {
+        let shouldReinstall = withStateLock { () -> Bool in
+          guard self._state.googleMapId != nextGoogleMapId else {
+            return false
+          }
+
+          self._state.googleMapId = nextGoogleMapId
+          return self._state.provider == .google && self.adapter != nil
+        }
+
+        guard shouldReinstall else {
           return
         }
 
-        _googleMapId = newValue
-        if _provider == .google, adapter != nil {
-          installAdapter(for: _provider)
-        }
+        installAdapter(for: withStateLock { self._state.provider })
       }
     }
   }
 
   var clusteringEnabled: Bool? {
-    get { _clusteringEnabled }
+    get { getBacked(\.clusteringEnabled) }
     set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _clusteringEnabled = newValue
-        adapter?.clusteringEnabled = newValue
-      }
+      setBackedOnMain(newValue, store: \.clusteringEnabled) { $0.clusteringEnabled = $1 }
     }
   }
 
   var mapPadding: EdgePadding? {
-    get { _mapPadding }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _mapPadding = newValue
-        adapter?.mapPadding = newValue
-      }
-    }
+    get { getBacked(\.mapPadding) }
+    set { setBackedOnMain(newValue, store: \.mapPadding) { $0.mapPadding = $1 } }
   }
 
   var markerEnteringAnimation: OverlayEnteringAnimationDescriptor? {
-    get { _markerEnteringAnimation }
+    get { getBacked(\.markerEnteringAnimation) }
     set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _markerEnteringAnimation = newValue
-        adapter?.markerEnteringAnimation = newValue
+      setBackedOnMain(newValue, store: \.markerEnteringAnimation) {
+        $0.markerEnteringAnimation = $1
       }
     }
   }
 
   var clusterEnteringAnimation: OverlayEnteringAnimationDescriptor? {
-    get { _clusterEnteringAnimation }
+    get { getBacked(\.clusterEnteringAnimation) }
     set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _clusterEnteringAnimation = newValue
-        adapter?.clusterEnteringAnimation = newValue
+      setBackedOnMain(newValue, store: \.clusterEnteringAnimation) {
+        $0.clusterEnteringAnimation = $1
       }
     }
   }
 
   var onRegionChange: ((Region) -> Void)? {
-    get { _onRegionChange }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onRegionChange = newValue
-        adapter?.onRegionChange = newValue
-      }
-    }
+    get { getBacked(\.onRegionChange) }
+    set { setBackedOnMain(newValue, store: \.onRegionChange) { $0.onRegionChange = $1 } }
   }
 
   var onRegionChangeComplete: ((Region) -> Void)? {
-    get { _onRegionChangeComplete }
+    get { getBacked(\.onRegionChangeComplete) }
     set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onRegionChangeComplete = newValue
-        adapter?.onRegionChangeComplete = newValue
+      setBackedOnMain(newValue, store: \.onRegionChangeComplete) {
+        $0.onRegionChangeComplete = $1
       }
     }
   }
 
   var onMapReady: (() -> Void)? {
-    get { _onMapReady }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onMapReady = newValue
-        adapter?.onMapReady = newValue
-      }
-    }
+    get { getBacked(\.onMapReady) }
+    set { setBackedOnMain(newValue, store: \.onMapReady) { $0.onMapReady = $1 } }
   }
 
   var onPress: ((Coordinate) -> Void)? {
-    get { _onPress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onPress = newValue
-        adapter?.onPress = newValue
-      }
-    }
+    get { getBacked(\.onPress) }
+    set { setBackedOnMain(newValue, store: \.onPress) { $0.onPress = $1 } }
   }
 
   var onPoiPress: ((NativePoiPressEvent) -> Void)? {
-    get { _onPoiPress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onPoiPress = newValue
-        adapter?.onPoiPress = newValue
-      }
-    }
+    get { getBacked(\.onPoiPress) }
+    set { setBackedOnMain(newValue, store: \.onPoiPress) { $0.onPoiPress = $1 } }
   }
 
   var onLongPress: ((Coordinate) -> Void)? {
-    get { _onLongPress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onLongPress = newValue
-        adapter?.onLongPress = newValue
-      }
-    }
+    get { getBacked(\.onLongPress) }
+    set { setBackedOnMain(newValue, store: \.onLongPress) { $0.onLongPress = $1 } }
   }
 
   var markers: [MarkerDescriptor]? {
-    get { _markers }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _markers = newValue
-        adapter?.markers = newValue
-      }
-    }
+    get { getBacked(\.markers) }
+    set { setBackedOnMain(newValue, store: \.markers) { $0.markers = $1 } }
   }
 
   var polylines: [PolylineDescriptor]? {
-    get { _polylines }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _polylines = newValue
-        adapter?.polylines = newValue
-      }
-    }
+    get { getBacked(\.polylines) }
+    set { setBackedOnMain(newValue, store: \.polylines) { $0.polylines = $1 } }
   }
 
   var polygons: [PolygonDescriptor]? {
-    get { _polygons }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _polygons = newValue
-        adapter?.polygons = newValue
-      }
-    }
+    get { getBacked(\.polygons) }
+    set { setBackedOnMain(newValue, store: \.polygons) { $0.polygons = $1 } }
   }
 
   var circles: [CircleDescriptor]? {
-    get { _circles }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _circles = newValue
-        adapter?.circles = newValue
-      }
-    }
+    get { getBacked(\.circles) }
+    set { setBackedOnMain(newValue, store: \.circles) { $0.circles = $1 } }
   }
 
   var onMarkerPress: ((String) -> Void)? {
-    get { _onMarkerPress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onMarkerPress = newValue
-        adapter?.onMarkerPress = newValue
-      }
-    }
+    get { getBacked(\.onMarkerPress) }
+    set { setBackedOnMain(newValue, store: \.onMarkerPress) { $0.onMarkerPress = $1 } }
   }
 
   var onMarkerDragEnd: ((String, Coordinate) -> Void)? {
-    get { _onMarkerDragEnd }
+    get { getBacked(\.onMarkerDragEnd) }
     set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onMarkerDragEnd = newValue
-        adapter?.onMarkerDragEnd = newValue
-      }
+      setBackedOnMain(newValue, store: \.onMarkerDragEnd) { $0.onMarkerDragEnd = $1 }
     }
   }
 
   var onPolylinePress: ((String) -> Void)? {
-    get { _onPolylinePress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onPolylinePress = newValue
-        adapter?.onPolylinePress = newValue
-      }
-    }
+    get { getBacked(\.onPolylinePress) }
+    set { setBackedOnMain(newValue, store: \.onPolylinePress) { $0.onPolylinePress = $1 } }
   }
 
   var onPolygonPress: ((String) -> Void)? {
-    get { _onPolygonPress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onPolygonPress = newValue
-        adapter?.onPolygonPress = newValue
-      }
-    }
+    get { getBacked(\.onPolygonPress) }
+    set { setBackedOnMain(newValue, store: \.onPolygonPress) { $0.onPolygonPress = $1 } }
   }
 
   var onCirclePress: ((String) -> Void)? {
-    get { _onCirclePress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onCirclePress = newValue
-        adapter?.onCirclePress = newValue
-      }
-    }
+    get { getBacked(\.onCirclePress) }
+    set { setBackedOnMain(newValue, store: \.onCirclePress) { $0.onCirclePress = $1 } }
   }
 
   var onClusterPress: (([String], Coordinate) -> Void)? {
-    get { _onClusterPress }
-    set {
-      runOnMain { [weak self] in
-        guard let self else {
-          return
-        }
-
-        _onClusterPress = newValue
-        adapter?.onClusterPress = newValue
-      }
-    }
+    get { getBacked(\.onClusterPress) }
+    set { setBackedOnMain(newValue, store: \.onClusterPress) { $0.onClusterPress = $1 } }
   }
 
   func fetchCamera() throws -> Promise<Camera> {
@@ -582,40 +296,9 @@ final class HybridMapView: HybridMapViewSpec {
       adapter?.prepareForRecycle()
       adapter?.contentView.removeFromSuperview()
       adapter = nil
-      _provider = .apple
-      _mapType = .standard
-      _region = nil
-      _camera = nil
-      _scrollEnabled = nil
-      _zoomEnabled = nil
-      _rotateEnabled = nil
-      _pitchEnabled = nil
-      _showsUserLocation = nil
-      _followsUserLocation = nil
-      _showsCompass = nil
-      _showsScale = nil
-      _customMapStyle = nil
-      _googleMapId = nil
-      _clusteringEnabled = nil
-      _mapPadding = nil
-      _markerEnteringAnimation = nil
-      _clusterEnteringAnimation = nil
-      _markers = nil
-      _polylines = nil
-      _polygons = nil
-      _circles = nil
-      _onRegionChange = nil
-      _onRegionChangeComplete = nil
-      _onMapReady = nil
-      _onPress = nil
-      _onPoiPress = nil
-      _onLongPress = nil
-      _onMarkerPress = nil
-      _onMarkerDragEnd = nil
-      _onPolylinePress = nil
-      _onPolygonPress = nil
-      _onCirclePress = nil
-      _onClusterPress = nil
+      withStateLock {
+        self._state = MapViewState()
+      }
     }
   }
 
@@ -628,7 +311,7 @@ final class HybridMapView: HybridMapViewSpec {
       return adapter
     }
 
-    installAdapter(for: _provider)
+    installAdapter(for: withStateLock { self._state.provider })
     return adapter!
   }
 
@@ -694,7 +377,7 @@ final class HybridMapView: HybridMapViewSpec {
       return AppleMapProviderAdapter()
     case .google:
       do {
-        return try GoogleMapProviderAdapter(googleMapId: _googleMapId)
+        return try GoogleMapProviderAdapter(googleMapId: withStateLock { self._state.googleMapId })
       } catch {
         return UnavailableMapProviderAdapter(error: error)
       }
@@ -717,39 +400,33 @@ final class HybridMapView: HybridMapViewSpec {
   }
 
   private func syncState(to adapter: MapProviderAdapter) {
-    adapter.mapType = _mapType
-    adapter.region = _region
-    adapter.camera = _camera
-    adapter.scrollEnabled = _scrollEnabled
-    adapter.zoomEnabled = _zoomEnabled
-    adapter.rotateEnabled = _rotateEnabled
-    adapter.pitchEnabled = _pitchEnabled
-    adapter.showsUserLocation = _showsUserLocation
-    adapter.followsUserLocation = _followsUserLocation
-    adapter.showsCompass = _showsCompass
-    adapter.showsScale = _showsScale
-    adapter.customMapStyle = _customMapStyle
-    adapter.googleMapId = _googleMapId
-    adapter.clusteringEnabled = _clusteringEnabled
-    adapter.mapPadding = _mapPadding
-    adapter.markerEnteringAnimation = _markerEnteringAnimation
-    adapter.clusterEnteringAnimation = _clusterEnteringAnimation
-    adapter.onRegionChange = _onRegionChange
-    adapter.onRegionChangeComplete = _onRegionChangeComplete
-    adapter.onMapReady = _onMapReady
-    adapter.onPress = _onPress
-    adapter.onPoiPress = _onPoiPress
-    adapter.onLongPress = _onLongPress
-    adapter.markers = _markers
-    adapter.polylines = _polylines
-    adapter.polygons = _polygons
-    adapter.circles = _circles
-    adapter.onMarkerPress = _onMarkerPress
-    adapter.onMarkerDragEnd = _onMarkerDragEnd
-    adapter.onPolylinePress = _onPolylinePress
-    adapter.onPolygonPress = _onPolygonPress
-    adapter.onCirclePress = _onCirclePress
-    adapter.onClusterPress = _onClusterPress
+    let snapshot = withStateLock { self._state }
+    snapshot.apply(to: adapter)
+  }
+
+  private func withStateLock<T>(_ body: () -> T) -> T {
+    stateLock.lock()
+    defer { stateLock.unlock() }
+    return body()
+  }
+
+  private func getBacked<T>(_ keyPath: KeyPath<MapViewState, T>) -> T {
+    withStateLock { self._state[keyPath: keyPath] }
+  }
+
+  private func setBackedOnMain<T>(
+    _ value: T,
+    store: WritableKeyPath<MapViewState, T>,
+    sync: @escaping (MapProviderAdapter, T) -> Void
+  ) {
+    withStateLock { self._state[keyPath: store] = value }
+    runOnMain { [weak self] in
+      guard let self, let adapter = self.adapter else {
+        return
+      }
+
+      sync(adapter, value)
+    }
   }
 
   private func runOnMain(_ work: @escaping () -> Void) {

--- a/package/ios/MapViewState.swift
+++ b/package/ios/MapViewState.swift
@@ -1,0 +1,74 @@
+import NitroModules
+
+struct MapViewState {
+  var provider: MapProvider = .apple
+  var mapType: MapType = .standard
+  var region: Region?
+  var camera: Camera?
+  var scrollEnabled: Bool?
+  var zoomEnabled: Bool?
+  var rotateEnabled: Bool?
+  var pitchEnabled: Bool?
+  var showsUserLocation: Bool?
+  var followsUserLocation: Bool?
+  var showsCompass: Bool?
+  var showsScale: Bool?
+  var customMapStyle: String?
+  var googleMapId: String?
+  var clusteringEnabled: Bool?
+  var mapPadding: EdgePadding?
+  var markerEnteringAnimation: OverlayEnteringAnimationDescriptor?
+  var clusterEnteringAnimation: OverlayEnteringAnimationDescriptor?
+  var onRegionChange: ((Region) -> Void)?
+  var onRegionChangeComplete: ((Region) -> Void)?
+  var onMapReady: (() -> Void)?
+  var onPress: ((Coordinate) -> Void)?
+  var onPoiPress: ((NativePoiPressEvent) -> Void)?
+  var onLongPress: ((Coordinate) -> Void)?
+  var markers: [MarkerDescriptor]?
+  var polylines: [PolylineDescriptor]?
+  var polygons: [PolygonDescriptor]?
+  var circles: [CircleDescriptor]?
+  var onMarkerPress: ((String) -> Void)?
+  var onMarkerDragEnd: ((String, Coordinate) -> Void)?
+  var onPolylinePress: ((String) -> Void)?
+  var onPolygonPress: ((String) -> Void)?
+  var onCirclePress: ((String) -> Void)?
+  var onClusterPress: (([String], Coordinate) -> Void)?
+
+  func apply(to adapter: MapProviderAdapter) {
+    adapter.mapType = mapType
+    adapter.region = region
+    adapter.camera = camera
+    adapter.scrollEnabled = scrollEnabled
+    adapter.zoomEnabled = zoomEnabled
+    adapter.rotateEnabled = rotateEnabled
+    adapter.pitchEnabled = pitchEnabled
+    adapter.showsUserLocation = showsUserLocation
+    adapter.followsUserLocation = followsUserLocation
+    adapter.showsCompass = showsCompass
+    adapter.showsScale = showsScale
+    adapter.customMapStyle = customMapStyle
+    adapter.googleMapId = googleMapId
+    adapter.clusteringEnabled = clusteringEnabled
+    adapter.mapPadding = mapPadding
+    adapter.markerEnteringAnimation = markerEnteringAnimation
+    adapter.clusterEnteringAnimation = clusterEnteringAnimation
+    adapter.onRegionChange = onRegionChange
+    adapter.onRegionChangeComplete = onRegionChangeComplete
+    adapter.onMapReady = onMapReady
+    adapter.onPress = onPress
+    adapter.onPoiPress = onPoiPress
+    adapter.onLongPress = onLongPress
+    adapter.markers = markers
+    adapter.polylines = polylines
+    adapter.polygons = polygons
+    adapter.circles = circles
+    adapter.onMarkerPress = onMarkerPress
+    adapter.onMarkerDragEnd = onMarkerDragEnd
+    adapter.onPolylinePress = onPolylinePress
+    adapter.onPolygonPress = onPolygonPress
+    adapter.onCirclePress = onCirclePress
+    adapter.onClusterPress = onClusterPress
+  }
+}

--- a/package/src/components/MapView.tsx
+++ b/package/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, type RefObject } from 'react';
 import { callback } from 'react-native-nitro-modules';
 import { useCollectedOverlays } from '../hooks/useCollectedOverlays';
 import { NativeMapView } from '../native/MapViewNative';
@@ -13,6 +13,20 @@ import type { Coordinate } from '../types/coordinate';
 import type { MapViewProps, PoiPressEvent } from '../types/map';
 import type { MapViewRef } from '../types/ref';
 import { normalizeEnteringAnimation } from '../utils/enteringAnimation';
+
+const MAP_VIEW_NOT_MOUNTED_ERROR = 'MapView is not mounted';
+
+function withHybridRef<T>(
+  hybridRef: RefObject<NativeMapViewHybrid | null>,
+  run: (hybrid: NativeMapViewHybrid) => T,
+): T {
+  const hybrid = hybridRef.current;
+  if (hybrid == null) {
+    return Promise.reject(new Error(MAP_VIEW_NOT_MOUNTED_ERROR)) as T;
+  }
+
+  return run(hybrid);
+}
 
 export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
   {
@@ -167,36 +181,20 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
   useImperativeHandle(
     ref,
     () => ({
-      getCamera: () => {
-        if (hybridRef.current == null) {
-          return Promise.reject(new Error('MapView is not mounted'));
-        }
-        return hybridRef.current.fetchCamera();
-      },
-      setCamera: (nextCamera) => {
-        if (hybridRef.current == null) {
-          return Promise.reject(new Error('MapView is not mounted'));
-        }
-        return hybridRef.current.applyCamera(nextCamera);
-      },
-      animateCamera: (nextCamera, duration) => {
-        if (hybridRef.current == null) {
-          return Promise.reject(new Error('MapView is not mounted'));
-        }
-        return hybridRef.current.animateCamera(nextCamera, duration);
-      },
-      getVisibleRegion: () => {
-        if (hybridRef.current == null) {
-          return Promise.reject(new Error('MapView is not mounted'));
-        }
-        return hybridRef.current.getVisibleRegion();
-      },
-      fitToCoordinates: (coordinates, padding, animated) => {
-        if (hybridRef.current == null) {
-          return Promise.reject(new Error('MapView is not mounted'));
-        }
-        return hybridRef.current.fitToCoordinates(coordinates, padding, animated);
-      },
+      getCamera: () =>
+        withHybridRef(hybridRef, (hybrid) => hybrid.fetchCamera()),
+      setCamera: (nextCamera) =>
+        withHybridRef(hybridRef, (hybrid) => hybrid.applyCamera(nextCamera)),
+      animateCamera: (nextCamera, duration) =>
+        withHybridRef(hybridRef, (hybrid) =>
+          hybrid.animateCamera(nextCamera, duration),
+        ),
+      getVisibleRegion: () =>
+        withHybridRef(hybridRef, (hybrid) => hybrid.getVisibleRegion()),
+      fitToCoordinates: (coordinates, padding, animated) =>
+        withHybridRef(hybridRef, (hybrid) =>
+          hybrid.fitToCoordinates(coordinates, padding, animated),
+        ),
     }),
     [],
   );

--- a/package/src/components/MapView.tsx
+++ b/package/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, type RefObject } from 'react';
+import { useCallback, useImperativeHandle, useMemo, useRef, type Ref, type RefObject } from 'react';
 import { callback } from 'react-native-nitro-modules';
 import { useCollectedOverlays } from '../hooks/useCollectedOverlays';
 import { NativeMapView } from '../native/MapViewNative';
@@ -28,47 +28,45 @@ function withHybridRef<T>(
   return run(hybrid);
 }
 
-export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
-  {
-    style,
-    children,
-    provider,
-    googleMapId,
-    region,
-    camera,
-    mapType = 'standard',
-    scrollEnabled,
-    zoomEnabled,
-    rotateEnabled,
-    pitchEnabled,
-    showsUserLocation,
-    followsUserLocation,
-    showsCompass,
-    showsScale,
-    customMapStyle,
-    clusteringEnabled,
-    mapPadding,
-    markerEnteringAnimation,
-    clusterEnteringAnimation,
-    markers: markersProp,
-    polylines: polylinesProp,
-    polygons: polygonsProp,
-    circles: circlesProp,
-    onRegionChange,
-    onRegionChangeComplete,
-    onMapReady,
-    onPress,
-    onPoiPress,
-    onLongPress,
-    onClusterPress,
-    onMarkerPress: onMarkerPressProp,
-    onMarkerDragEnd: onMarkerDragEndProp,
-    onPolylinePress: onPolylinePressProp,
-    onPolygonPress: onPolygonPressProp,
-    onCirclePress: onCirclePressProp,
-  },
+export function MapView({
   ref,
-) {
+  style,
+  children,
+  provider,
+  googleMapId,
+  region,
+  camera,
+  mapType = 'standard',
+  scrollEnabled,
+  zoomEnabled,
+  rotateEnabled,
+  pitchEnabled,
+  showsUserLocation,
+  followsUserLocation,
+  showsCompass,
+  showsScale,
+  customMapStyle,
+  clusteringEnabled,
+  mapPadding,
+  markerEnteringAnimation,
+  clusterEnteringAnimation,
+  markers: markersProp,
+  polylines: polylinesProp,
+  polygons: polygonsProp,
+  circles: circlesProp,
+  onRegionChange,
+  onRegionChangeComplete,
+  onMapReady,
+  onPress,
+  onPoiPress,
+  onLongPress,
+  onClusterPress,
+  onMarkerPress: onMarkerPressProp,
+  onMarkerDragEnd: onMarkerDragEndProp,
+  onPolylinePress: onPolylinePressProp,
+  onPolygonPress: onPolygonPressProp,
+  onCirclePress: onCirclePressProp,
+}: MapViewProps & { ref?: Ref<MapViewRef> }) {
   const resolvedProvider = resolveMapProvider(provider);
   const hybridRef = useRef<NativeMapViewHybrid>(null);
   const {
@@ -260,4 +258,4 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
       }
     />
   );
-});
+}

--- a/package/src/components/MapView.tsx
+++ b/package/src/components/MapView.tsx
@@ -174,10 +174,16 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
         return hybridRef.current.fetchCamera();
       },
       setCamera: (nextCamera) => {
-        hybridRef.current?.applyCamera(nextCamera);
+        if (hybridRef.current == null) {
+          return Promise.reject(new Error('MapView is not mounted'));
+        }
+        return hybridRef.current.applyCamera(nextCamera);
       },
       animateCamera: (nextCamera, duration) => {
-        hybridRef.current?.animateCamera(nextCamera, duration);
+        if (hybridRef.current == null) {
+          return Promise.reject(new Error('MapView is not mounted'));
+        }
+        return hybridRef.current.animateCamera(nextCamera, duration);
       },
       getVisibleRegion: () => {
         if (hybridRef.current == null) {
@@ -186,7 +192,10 @@ export const MapView = forwardRef<MapViewRef, MapViewProps>(function MapView(
         return hybridRef.current.getVisibleRegion();
       },
       fitToCoordinates: (coordinates, padding, animated) => {
-        hybridRef.current?.fitToCoordinates(coordinates, padding, animated);
+        if (hybridRef.current == null) {
+          return Promise.reject(new Error('MapView is not mounted'));
+        }
+        return hybridRef.current.fitToCoordinates(coordinates, padding, animated);
       },
     }),
     [],

--- a/package/src/native/specs/MapView.nitro.ts
+++ b/package/src/native/specs/MapView.nitro.ts
@@ -236,10 +236,10 @@ export interface MapViewMethods extends HybridViewMethods {
    * Named `applyCamera` in the Nitro spec to avoid colliding with the `camera`
    * prop accessor (`getCamera`/`setCamera`) in generated C++ bindings.
    */
-  applyCamera(camera: Camera): void;
+  applyCamera(camera: Camera): Promise<void>;
 
   /** Animates the camera to the given position. */
-  animateCamera(camera: Camera, duration?: number): void;
+  animateCamera(camera: Camera, duration?: number): Promise<void>;
 
   /** Returns the currently visible geographic region. */
   getVisibleRegion(): Promise<VisibleRegion>;
@@ -249,7 +249,7 @@ export interface MapViewMethods extends HybridViewMethods {
     coordinates: Coordinate[],
     padding?: EdgePadding,
     animated?: boolean,
-  ): void;
+  ): Promise<void>;
 }
 
 /**

--- a/package/src/types/ref.ts
+++ b/package/src/types/ref.ts
@@ -10,10 +10,10 @@ export interface MapViewRef {
   getCamera(): Promise<Camera>;
 
   /** Sets the camera position immediately. */
-  setCamera(camera: Camera): void;
+  setCamera(camera: Camera): Promise<void>;
 
   /** Animates the camera to the given position. */
-  animateCamera(camera: Camera, duration?: number): void;
+  animateCamera(camera: Camera, duration?: number): Promise<void>;
 
   /** Returns the currently visible geographic region. */
   getVisibleRegion(): Promise<VisibleRegion>;
@@ -23,5 +23,5 @@ export interface MapViewRef {
     coordinates: Coordinate[],
     padding?: EdgePadding,
     animated?: boolean,
-  ): void;
+  ): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Remove `DispatchQueue.main.sync` from `HybridMapView` — property getters read backing fields directly; setters and lifecycle hooks use non-blocking `runOnMain` (`async` dispatch).
- Convert `applyCamera`, `animateCamera`, and `fitToCoordinates` to `Promise<void>` in the Nitro spec and native implementations, matching the existing `promiseOnMain` pattern used by `fetchCamera` / `getVisibleRegion`.
- Update `MapViewRef` and the React wrapper to propagate promises and reject when the view is not mounted.

This addresses deadlock risk when imperative camera calls from the JS thread block on main while main is waiting on JS/Fabric, and removes unnecessary per-getter main round-trips.

Follow-up to #43 — that PR did not remove the `onMain` / `.sync` pattern.

## Test plan

- [ ] `bun run typecheck` in `package/`
- [ ] `bun run nitrogen` in `package/` (codegen required after spec change)
- [ ] iOS example: `animateCamera`, `setCamera`, `fitToCoordinates` from ref work without UI freeze
- [ ] iOS example: rapid prop updates (markers, mapType) render correctly
- [ ] Android example: camera ref methods still work (`Promise.resolved` on UI thread)