### PR TITLE
feat: enhance map region change handling and improve camera update logic

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: React Doctor
-        uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3 # v2
+        uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2.2.8
         with:
           project: 'package,example'
           blocking: none

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -46,8 +46,14 @@ import {
   type MapViewRef,
   type OverlayEnteringAnimation,
   type PoiPressEvent,
+  Region,
 } from 'react-native-better-maps';
-import { MAP_SCENARIOS, type MapScenario, createCustomMarkerImagesScenario, CUSTOM_MARKER_IMAGES_SCENARIO_ID } from './examples';
+import {
+  MAP_SCENARIOS,
+  type MapScenario,
+  createCustomMarkerImagesScenario,
+  CUSTOM_MARKER_IMAGES_SCENARIO_ID,
+} from './examples';
 
 const MAP_TYPES: MapType[] = ['standard', 'satellite', 'hybrid'];
 type SupportedExampleProvider = Extract<MapProvider, 'apple' | 'google'>;
@@ -498,6 +504,8 @@ type MapSceneProps = {
   onPress: (coordinate: Coordinate) => void;
   onPoiPress: (event: PoiPressEvent) => void;
   onLongPress: (coordinate: Coordinate) => void;
+  onRegionChange: (region: Region) => void;
+  onRegionChangeComplete: (region: Region) => void;
 };
 
 const MapScene = memo(
@@ -516,6 +524,8 @@ const MapScene = memo(
       onPress,
       onPoiPress,
       onLongPress,
+      onRegionChange,
+      onRegionChangeComplete,
     },
     ref,
   ) {
@@ -547,6 +557,8 @@ const MapScene = memo(
       onPolylinePress: onOverlayPress,
       onPolygonPress: onOverlayPress,
       onCirclePress: onOverlayPress,
+      onRegionChange,
+      onRegionChangeComplete,
     };
 
     if (provider === 'apple') {
@@ -819,6 +831,12 @@ export default function App() {
     );
   }, []);
 
+  const updateRegionStatus = useCallback((region: Region) => {
+    setStatus(
+      `Region · ${region.latitude.toFixed(4)}, ${region.longitude.toFixed(4)}`,
+    );
+  }, []);
+
   return (
     <View style={styles.container}>
       <MapScene
@@ -836,6 +854,8 @@ export default function App() {
         onPress={handleMapPress}
         onPoiPress={handlePoiPress}
         onLongPress={handleMapLongPress}
+        onRegionChange={updateRegionStatus}
+        onRegionChangeComplete={updateRegionStatus}
       />
 
       <StatusHeader

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -831,9 +831,15 @@ export default function App() {
     );
   }, []);
 
-  const updateRegionStatus = useCallback((region: Region) => {
+  const handleRegionChange = useCallback((region: Region) => {
     setStatus(
-      `Region · ${region.latitude.toFixed(4)}, ${region.longitude.toFixed(4)}`,
+      `Region start · ${region.latitude.toFixed(4)}, ${region.longitude.toFixed(4)}`,
+    );
+  }, []);
+
+  const handleRegionChangeComplete = useCallback((region: Region) => {
+    setStatus(
+      `Region complete · ${region.latitude.toFixed(4)}, ${region.longitude.toFixed(4)}`,
     );
   }, []);
 
@@ -854,8 +860,8 @@ export default function App() {
         onPress={handleMapPress}
         onPoiPress={handlePoiPress}
         onLongPress={handleMapLongPress}
-        onRegionChange={updateRegionStatus}
-        onRegionChangeComplete={updateRegionStatus}
+        onRegionChange={handleRegionChange}
+        onRegionChangeComplete={handleRegionChangeComplete}
       />
 
       <StatusHeader

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/Camera+CameraPosition.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/Camera+CameraPosition.kt
@@ -2,6 +2,7 @@ package com.margelo.nitro.nitromaps
 
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import kotlin.math.abs
 
 fun Camera.toCameraPosition(current: CameraPosition? = null): CameraPosition {
   return CameraPosition.Builder()
@@ -20,4 +21,17 @@ fun CameraPosition.toCamera(): Camera {
     pitch = tilt.toDouble(),
     altitude = null,
   )
+}
+
+fun CameraPosition.approximatelyEquals(
+  other: CameraPosition,
+  coordinateEpsilon: Double = MapApproximateEquality.COORDINATE_EPSILON,
+  zoomEpsilon: Float = MapApproximateEquality.ZOOM_EPSILON,
+  angleEpsilon: Float = MapApproximateEquality.ANGLE_EPSILON,
+): Boolean {
+  return abs(target.latitude - other.target.latitude) < coordinateEpsilon
+    && abs(target.longitude - other.target.longitude) < coordinateEpsilon
+    && abs(zoom - other.zoom) < zoomEpsilon
+    && abs(bearing - other.bearing) < angleEpsilon
+    && abs(tilt - other.tilt) < angleEpsilon
 }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
@@ -677,7 +677,7 @@ class GoogleMapProviderAdapter(
   }
 
   private fun handleRegionWillChange(userInteracting: Boolean) {
-    if (userInteracting) {
+    if (userInteracting && !isUserGesture) {
       isUserGesture = true
       emitRegionChange(complete = false)
     }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
@@ -30,8 +30,7 @@ class GoogleMapProviderAdapter(
   LifecycleEventListener {
 
   private var googleMap: GoogleMap? = null
-  private var isProgrammaticUpdate = false
-  private var programmaticUpdateCount = 0
+  private var isUserGesture = false
   private var hasFiredMapReady = false
   private var isDestroyed = false
   private val overlayController = MapOverlayController(null, context)
@@ -91,7 +90,7 @@ class GoogleMapProviderAdapter(
     get() = _region
     set(value) {
       _region = value
-      if (value != null && !isProgrammaticUpdate && _camera == null) {
+      if (value != null && !isUserGesture && _camera == null) {
         applyRegion(value)
       }
     }
@@ -101,7 +100,7 @@ class GoogleMapProviderAdapter(
     get() = _camera
     set(value) {
       _camera = value
-      if (value != null && !isProgrammaticUpdate) {
+      if (value != null && !isUserGesture) {
         updateMapCamera(value, animated = false)
       }
     }
@@ -366,13 +365,9 @@ class GoogleMapProviderAdapter(
       val runUpdate = {
         val update = CameraUpdateFactory.newLatLngBounds(bounds, paddingPx)
         if (animated == true) {
-          animateProgrammaticCameraUpdate {
-            map.animateCamera(update, it)
-          }
+          map.animateCamera(update)
         } else {
-          moveProgrammaticCameraUpdate {
-            map.moveCamera(update)
-          }
+          map.moveCamera(update)
         }
       }
 
@@ -408,13 +403,17 @@ class GoogleMapProviderAdapter(
     overlayController.setClusteringEnabled(_clusteringEnabled == true)
     syncMarkerPressHandlers()
 
+    map.setOnCameraMoveStartedListener { reason ->
+      handleRegionWillChange(
+        userInteracting = reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE,
+      )
+    }
     map.setOnCameraMoveListener {
       overlayController.onCameraMove()
-      notifyRegionChange(complete = false)
     }
     map.setOnCameraIdleListener {
       overlayController.onCameraIdle()
-      notifyRegionChange(complete = true)
+      handleRegionDidChange()
     }
     map.setOnMapClickListener { latLng ->
       onPress?.invoke(latLng.toCoordinate())
@@ -580,13 +579,9 @@ class GoogleMapProviderAdapter(
     val runUpdate = {
       val update = CameraUpdateFactory.newLatLngBounds(bounds, paddingPx)
       if (animated) {
-        animateProgrammaticCameraUpdate {
-          map.animateCamera(update, it)
-        }
+        map.animateCamera(update)
       } else {
-        moveProgrammaticCameraUpdate {
-          map.moveCamera(update)
-        }
+        map.moveCamera(update)
       }
     }
 
@@ -600,18 +595,20 @@ class GoogleMapProviderAdapter(
   ) {
     runOnMain {
       val map = googleMap ?: return@runOnMain
-      val update = CameraUpdateFactory.newCameraPosition(
-        camera.toCameraPosition(map.cameraPosition),
-      )
+      val target = camera.toCameraPosition(map.cameraPosition)
+      if (map.cameraPosition.approximatelyEquals(target)) {
+        return@runOnMain
+      }
 
+      val update = CameraUpdateFactory.newCameraPosition(target)
       if (animated) {
-        animateProgrammaticCameraUpdate {
-          map.animateCamera(update, durationMs, it)
+        if (durationMs > 0) {
+          map.animateCamera(update, durationMs, null)
+        } else {
+          map.animateCamera(update)
         }
       } else {
-        moveProgrammaticCameraUpdate {
-          map.moveCamera(update)
-        }
+        map.moveCamera(update)
       }
     }
   }
@@ -679,44 +676,26 @@ class GoogleMapProviderAdapter(
     return promise
   }
 
-  private fun beginProgrammaticUpdate() {
-    programmaticUpdateCount += 1
-    isProgrammaticUpdate = true
-  }
-
-  private fun endProgrammaticUpdate() {
-    if (programmaticUpdateCount > 0) {
-      programmaticUpdateCount -= 1
-    }
-    isProgrammaticUpdate = programmaticUpdateCount > 0
-  }
-
-  private fun moveProgrammaticCameraUpdate(block: () -> Unit) {
-    beginProgrammaticUpdate()
-    try {
-      block()
-    } finally {
-      endProgrammaticUpdate()
+  private fun handleRegionWillChange(userInteracting: Boolean) {
+    if (userInteracting) {
+      isUserGesture = true
+      emitRegionChange(complete = false)
     }
   }
 
-  private fun animateProgrammaticCameraUpdate(block: (GoogleMap.CancelableCallback) -> Unit) {
-    beginProgrammaticUpdate()
-    try {
-      block(
-        object : GoogleMap.CancelableCallback {
-          override fun onFinish() {
-            endProgrammaticUpdate()
-          }
+  private fun handleRegionDidChange() {
+    if (isUserGesture) {
+      emitRegionChange(complete = true)
+      isUserGesture = false
+    }
+  }
 
-          override fun onCancel() {
-            endProgrammaticUpdate()
-          }
-        },
-      )
-    } catch (throwable: Throwable) {
-      endProgrammaticUpdate()
-      throw throwable
+  private fun emitRegionChange(complete: Boolean) {
+    val region = currentRegion()
+    if (complete) {
+      onRegionChangeComplete?.invoke(region)
+    } else {
+      onRegionChange?.invoke(region)
     }
   }
 
@@ -734,19 +713,6 @@ class GoogleMapProviderAdapter(
     )
   }
 
-  private fun notifyRegionChange(complete: Boolean) {
-    if (isProgrammaticUpdate) {
-      return
-    }
-
-    val region = currentRegion()
-    if (complete) {
-      onRegionChangeComplete?.invoke(region)
-    } else {
-      onRegionChange?.invoke(region)
-    }
-  }
-
   private fun notifyMapReadyIfNeeded() {
     if (hasFiredMapReady) {
       return
@@ -757,8 +723,7 @@ class GoogleMapProviderAdapter(
   }
 
   override fun prepareForRecycle() {
-    isProgrammaticUpdate = false
-    programmaticUpdateCount = 0
+    isUserGesture = false
     hasFiredMapReady = false
     onRegionChange = null
     onRegionChangeComplete = null

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapApproximateEquality.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapApproximateEquality.kt
@@ -1,0 +1,7 @@
+package com.margelo.nitro.nitromaps
+
+object MapApproximateEquality {
+  const val COORDINATE_EPSILON: Double = 1e-6
+  const val ZOOM_EPSILON: Float = 1e-4f
+  const val ANGLE_EPSILON: Float = 1e-3f
+}

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapOverlayController.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapOverlayController.kt
@@ -11,6 +11,7 @@ import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.Polygon

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapOverlayController.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapOverlayController.kt
@@ -11,7 +11,6 @@ import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.Polygon

--- a/package/ios/AppleMapProviderAdapter.swift
+++ b/package/ios/AppleMapProviderAdapter.swift
@@ -4,9 +4,7 @@ import UIKit
 
 final class AppleMapProviderAdapter: MapProviderAdapter {
   private let mapViewDelegate = HybridMapViewDelegate()
-  private var isProgrammaticUpdate = false
-  private var pendingProgrammaticUpdateIDs: [Int] = []
-  private var nextProgrammaticUpdateID = 0
+  private var isUserRegionChange = false
   private var isMapReady = false
   private var hasDeliveredMapReady = false
   private var liveClusterTimer: Timer?
@@ -55,7 +53,7 @@ final class AppleMapProviderAdapter: MapProviderAdapter {
 
   var region: Region? {
     didSet {
-      guard let region, !isProgrammaticUpdate, camera == nil else {
+      guard let region, !view.isUserInteracting, camera == nil else {
         return
       }
       applyRegion(region)
@@ -64,7 +62,7 @@ final class AppleMapProviderAdapter: MapProviderAdapter {
 
   var camera: Camera? {
     didSet {
-      guard let camera, !isProgrammaticUpdate else {
+      guard let camera, !view.isUserInteracting else {
         return
       }
       updateMapCamera(camera, animated: false)
@@ -237,45 +235,37 @@ final class AppleMapProviderAdapter: MapProviderAdapter {
 
     let edgePadding = padding?.toUIEdgeInsets() ?? .zero
     let shouldAnimate = animated ?? true
-    let updateID = beginProgrammaticUpdate()
     view.setVisibleMapRect(
       mapRect,
       edgePadding: edgePadding,
       animated: shouldAnimate
     )
-    scheduleProgrammaticUpdateFallback(
-      for: updateID,
-      delay: shouldAnimate ? 1.0 : 0
-    )
   }
 
   func applyRegion(_ region: Region, animated: Bool = false) {
-    let updateID = beginProgrammaticUpdate()
-    view.setRegion(region.toMKCoordinateRegion(), animated: animated)
-    scheduleProgrammaticUpdateFallback(
-      for: updateID,
-      delay: animated ? 1.0 : 0
-    )
+    let targetRegion = region.toMKCoordinateRegion()
+    guard !view.region.approximatelyEquals(targetRegion) else {
+      return
+    }
+
+    view.setRegion(targetRegion, animated: animated)
   }
 
   func updateMapCamera(_ camera: Camera, animated: Bool, duration: Double = 0) {
-    let updateID = beginProgrammaticUpdate()
     let mapCamera = camera.toMKMapCamera()
+    guard !view.camera.approximatelyEquals(mapCamera) else {
+      return
+    }
 
     if animated {
       UIView.animate(
         withDuration: duration,
         animations: {
           self.view.camera = mapCamera
-        },
-        completion: { [weak self] _ in
-          self?.endProgrammaticUpdate(updateID)
         }
       )
-      scheduleProgrammaticUpdateFallback(for: updateID, delay: duration + 0.1)
     } else {
       view.camera = mapCamera
-      scheduleProgrammaticUpdateFallback(for: updateID, delay: 0)
     }
   }
 
@@ -293,42 +283,35 @@ final class AppleMapProviderAdapter: MapProviderAdapter {
     view.setRegion(view.regionThatFits(region), animated: true)
   }
 
-  private func beginProgrammaticUpdate() -> Int {
-    nextProgrammaticUpdateID += 1
-    let updateID = nextProgrammaticUpdateID
-    pendingProgrammaticUpdateIDs.append(updateID)
-    isProgrammaticUpdate = true
-    return updateID
-  }
-
-  private func endProgrammaticUpdate(_ updateID: Int? = nil) {
-    if let updateID {
-      guard let index = pendingProgrammaticUpdateIDs.firstIndex(of: updateID) else {
-        return
-      }
-      pendingProgrammaticUpdateIDs.remove(at: index)
-    } else if !pendingProgrammaticUpdateIDs.isEmpty {
-      pendingProgrammaticUpdateIDs.removeFirst()
+  func handleRegionWillChange(userInteracting: Bool) {
+    startLiveClustering()
+    if userInteracting {
+      isUserRegionChange = true
+      emitRegionChange(complete: false)
     }
-
-    isProgrammaticUpdate = !pendingProgrammaticUpdateIDs.isEmpty
   }
 
-  func endProgrammaticRegionChangeIfNeeded() {
-    guard !pendingProgrammaticUpdateIDs.isEmpty else {
+  func handleRegionDidChange() {
+    stopLiveClustering()
+
+    guard isUserRegionChange else {
       return
     }
 
-    endProgrammaticUpdate()
+    guard !view.isUserInteracting else {
+      return
+    }
+
+    emitRegionChange(complete: true)
+    isUserRegionChange = false
   }
 
-  private func scheduleProgrammaticUpdateFallback(for updateID: Int, delay: TimeInterval) {
-    DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-      guard let self else {
-        return
-      }
-
-      self.endProgrammaticUpdate(updateID)
+  private func emitRegionChange(complete: Bool) {
+    let region = currentRegion()
+    if complete {
+      onRegionChangeComplete?(region)
+    } else {
+      onRegionChange?(region)
     }
   }
 
@@ -347,19 +330,6 @@ final class AppleMapProviderAdapter: MapProviderAdapter {
     liveClusterTimer?.invalidate()
     liveClusterTimer = nil
     overlayController.scheduleViewportRefresh(immediate: true)
-  }
-
-  func notifyRegionChange(complete: Bool) {
-    guard !isProgrammaticUpdate else {
-      return
-    }
-
-    let region = currentRegion()
-    if complete {
-      onRegionChangeComplete?(region)
-    } else {
-      onRegionChange?(region)
-    }
   }
 
   func notifyMapReadyIfNeeded() {
@@ -432,8 +402,7 @@ final class AppleMapProviderAdapter: MapProviderAdapter {
   func prepareForRecycle() {
     liveClusterTimer?.invalidate()
     liveClusterTimer = nil
-    isProgrammaticUpdate = false
-    pendingProgrammaticUpdateIDs.removeAll()
+    isUserRegionChange = false
     isMapReady = false
     hasDeliveredMapReady = false
     onRegionChange = nil

--- a/package/ios/AppleMapProviderAdapter.swift
+++ b/package/ios/AppleMapProviderAdapter.swift
@@ -285,10 +285,11 @@ final class AppleMapProviderAdapter: MapProviderAdapter {
 
   func handleRegionWillChange(userInteracting: Bool) {
     startLiveClustering()
-    if userInteracting {
-      isUserRegionChange = true
-      emitRegionChange(complete: false)
+    guard userInteracting, !isUserRegionChange else {
+      return
     }
+    isUserRegionChange = true
+    emitRegionChange(complete: false)
   }
 
   func handleRegionDidChange() {

--- a/package/ios/Camera+GMSCameraPosition.swift
+++ b/package/ios/Camera+GMSCameraPosition.swift
@@ -14,6 +14,19 @@ extension Camera {
 }
 
 extension GMSCameraPosition {
+  func approximatelyEquals(
+    _ other: GMSCameraPosition,
+    coordinateEpsilon: Double = MapApproximateEquality.coordinateEpsilon,
+    zoomEpsilon: Float = MapApproximateEquality.zoomEpsilon,
+    angleEpsilon: CLLocationDirection = MapApproximateEquality.angleEpsilon
+  ) -> Bool {
+    abs(target.latitude - other.target.latitude) < coordinateEpsilon
+      && abs(target.longitude - other.target.longitude) < coordinateEpsilon
+      && abs(zoom - other.zoom) < zoomEpsilon
+      && abs(bearing - other.bearing) < angleEpsilon
+      && abs(viewingAngle - other.viewingAngle) < angleEpsilon
+  }
+
   func toCamera() -> Camera {
     Camera(
       center: Coordinate(latitude: target.latitude, longitude: target.longitude),

--- a/package/ios/Camera+MKMapCamera.swift
+++ b/package/ios/Camera+MKMapCamera.swift
@@ -26,6 +26,19 @@ extension Camera {
 }
 
 extension MKMapCamera {
+  func approximatelyEquals(
+    _ other: MKMapCamera,
+    coordinateEpsilon: Double = MapApproximateEquality.coordinateEpsilon,
+    distanceEpsilon: Double = MapApproximateEquality.distanceEpsilon,
+    angleEpsilon: CLLocationDirection = MapApproximateEquality.angleEpsilon
+  ) -> Bool {
+    abs(centerCoordinate.latitude - other.centerCoordinate.latitude) < coordinateEpsilon
+      && abs(centerCoordinate.longitude - other.centerCoordinate.longitude) < coordinateEpsilon
+      && abs(centerCoordinateDistance - other.centerCoordinateDistance) < distanceEpsilon
+      && abs(heading - other.heading) < angleEpsilon
+      && abs(pitch - other.pitch) < angleEpsilon
+  }
+
   func toCamera() -> Camera {
     let centerCoordinate = Coordinate(
       latitude: centerCoordinate.latitude,

--- a/package/ios/GoogleMapProviderAdapter.swift
+++ b/package/ios/GoogleMapProviderAdapter.swift
@@ -11,6 +11,7 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
 
   private var isMapReady = false
   private var hasDeliveredMapReady = false
+  private var isUserRegionChange = false
   private var isUserGestureMoving = false
   private var lastLiveMarkerRefreshTime: CFTimeInterval = 0
   private var myLocationObservation: NSKeyValueObservation?
@@ -256,6 +257,7 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
   }
 
   func prepareForRecycle() {
+    isUserRegionChange = false
     isUserGestureMoving = false
     lastLiveMarkerRefreshTime = 0
     isMapReady = false
@@ -335,15 +337,19 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
   }
 
   private func handleRegionWillChange(userInteracting: Bool) {
-    if userInteracting {
-      emitRegionChange(complete: false)
+    guard userInteracting, !isUserRegionChange else {
+      return
     }
+    isUserRegionChange = true
+    emitRegionChange(complete: false)
   }
 
-  private func handleRegionDidChange(wasUserGesture: Bool) {
-    if wasUserGesture {
-      emitRegionChange(complete: true)
+  private func handleRegionDidChange() {
+    guard isUserRegionChange else {
+      return
     }
+    emitRegionChange(complete: true)
+    isUserRegionChange = false
   }
 
   private func emitRegionChange(complete: Bool) {
@@ -496,10 +502,10 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
 
 extension GoogleMapProviderAdapter: GMSMapViewDelegate {
   func mapView(_ mapView: GMSMapView, willMove gesture: Bool) {
+    handleRegionWillChange(userInteracting: gesture)
     if gesture {
       startGestureMarkerRefresh()
     }
-    handleRegionWillChange(userInteracting: gesture)
   }
 
   func mapView(_ mapView: GMSMapView, didChange position: GMSCameraPosition) {
@@ -507,10 +513,9 @@ extension GoogleMapProviderAdapter: GMSMapViewDelegate {
   }
 
   func mapView(_ mapView: GMSMapView, idleAt position: GMSCameraPosition) {
-    let wasUserGesture = isUserGestureMoving
     refreshVisibleMarkers()
     stopGestureMarkerRefresh()
-    handleRegionDidChange(wasUserGesture: wasUserGesture)
+    handleRegionDidChange()
     notifyMapReadyIfNeeded()
   }
 

--- a/package/ios/GoogleMapProviderAdapter.swift
+++ b/package/ios/GoogleMapProviderAdapter.swift
@@ -9,9 +9,6 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
   private static let liveGestureRefreshInterval: CFTimeInterval = 0.18
   private static let liveGestureAnimationBudget = 24
 
-  private var isProgrammaticUpdate = false
-  private var pendingProgrammaticUpdateIDs: [Int] = []
-  private var nextProgrammaticUpdateID = 0
   private var isMapReady = false
   private var hasDeliveredMapReady = false
   private var isUserGestureMoving = false
@@ -75,7 +72,7 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
 
   var region: Region? {
     didSet {
-      guard let region, !isProgrammaticUpdate, camera == nil else {
+      guard let region, !isUserGestureMoving, camera == nil else {
         return
       }
       applyRegion(region)
@@ -84,7 +81,7 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
 
   var camera: Camera? {
     didSet {
-      guard let camera, !isProgrammaticUpdate else {
+      guard let camera, !isUserGestureMoving else {
         return
       }
       updateMapCamera(camera, animated: false)
@@ -261,8 +258,6 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
   func prepareForRecycle() {
     isUserGestureMoving = false
     lastLiveMarkerRefreshTime = 0
-    isProgrammaticUpdate = false
-    pendingProgrammaticUpdateIDs.removeAll()
     isMapReady = false
     hasDeliveredMapReady = false
     view.delegate = nil
@@ -311,7 +306,12 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
   }
 
   private func updateMapCamera(_ camera: Camera, animated: Bool, duration: Double? = nil) {
-    let update = GMSCameraUpdate.setCamera(camera.toGMSCameraPosition(current: view.camera))
+    let target = camera.toGMSCameraPosition(current: view.camera)
+    guard !view.camera.approximatelyEquals(target) else {
+      return
+    }
+
+    let update = GMSCameraUpdate.setCamera(target)
     applyCameraUpdate(update, animated: animated, duration: duration)
   }
 
@@ -320,51 +320,38 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
     animated: Bool,
     duration: Double?
   ) {
-    let updateID = beginProgrammaticUpdate()
     if animated {
       if let duration {
         CATransaction.begin()
         CATransaction.setAnimationDuration(duration)
-        CATransaction.setCompletionBlock { [weak self] in
-          self?.endProgrammaticUpdate(updateID)
-        }
         view.animate(with: update)
         CATransaction.commit()
-        scheduleProgrammaticUpdateFallback(for: updateID, delay: duration + 0.1)
       } else {
         view.animate(with: update)
-        scheduleProgrammaticUpdateFallback(for: updateID, delay: 0.5)
       }
     } else {
       view.moveCamera(update)
-      scheduleProgrammaticUpdateFallback(for: updateID, delay: 0)
     }
   }
 
-  private func beginProgrammaticUpdate() -> Int {
-    nextProgrammaticUpdateID += 1
-    let updateID = nextProgrammaticUpdateID
-    pendingProgrammaticUpdateIDs.append(updateID)
-    isProgrammaticUpdate = true
-    return updateID
-  }
-
-  private func endProgrammaticUpdate(_ updateID: Int? = nil) {
-    if let updateID {
-      guard let index = pendingProgrammaticUpdateIDs.firstIndex(of: updateID) else {
-        return
-      }
-      pendingProgrammaticUpdateIDs.remove(at: index)
-    } else if !pendingProgrammaticUpdateIDs.isEmpty {
-      pendingProgrammaticUpdateIDs.removeFirst()
+  private func handleRegionWillChange(userInteracting: Bool) {
+    if userInteracting {
+      emitRegionChange(complete: false)
     }
-
-    isProgrammaticUpdate = !pendingProgrammaticUpdateIDs.isEmpty
   }
 
-  private func scheduleProgrammaticUpdateFallback(for updateID: Int, delay: TimeInterval) {
-    DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-      self?.endProgrammaticUpdate(updateID)
+  private func handleRegionDidChange(wasUserGesture: Bool) {
+    if wasUserGesture {
+      emitRegionChange(complete: true)
+    }
+  }
+
+  private func emitRegionChange(complete: Bool) {
+    let region = view.currentNitroRegion()
+    if complete {
+      onRegionChangeComplete?(region)
+    } else {
+      onRegionChange?(region)
     }
   }
 
@@ -410,19 +397,6 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
   private func animateToClusterRegion(_ region: MKCoordinateRegion) {
     let bounds = region.toRegion().toGMSCoordinateBounds()
     view.animate(with: GMSCameraUpdate.fit(bounds, withPadding: 72))
-  }
-
-  private func notifyRegionChange(complete: Bool) {
-    guard !isProgrammaticUpdate else {
-      return
-    }
-
-    let region = view.currentNitroRegion()
-    if complete {
-      onRegionChangeComplete?(region)
-    } else {
-      onRegionChange?(region)
-    }
   }
 
   private func notifyMapReadyIfNeeded() {
@@ -499,9 +473,7 @@ final class GoogleMapProviderAdapter: NSObject, MapProviderAdapter {
   }
 
   private func animateToUserLocation(_ location: CLLocation, on mapView: GMSMapView) {
-    let updateID = beginProgrammaticUpdate()
     mapView.animate(with: GMSCameraUpdate.setTarget(location.coordinate))
-    scheduleProgrammaticUpdateFallback(for: updateID, delay: 0.5)
   }
 
   private func applyControlSettings(to mapView: GMSMapView) {
@@ -526,8 +498,8 @@ extension GoogleMapProviderAdapter: GMSMapViewDelegate {
   func mapView(_ mapView: GMSMapView, willMove gesture: Bool) {
     if gesture {
       startGestureMarkerRefresh()
-      notifyRegionChange(complete: false)
     }
+    handleRegionWillChange(userInteracting: gesture)
   }
 
   func mapView(_ mapView: GMSMapView, didChange position: GMSCameraPosition) {
@@ -535,10 +507,10 @@ extension GoogleMapProviderAdapter: GMSMapViewDelegate {
   }
 
   func mapView(_ mapView: GMSMapView, idleAt position: GMSCameraPosition) {
-    stopGestureMarkerRefresh()
+    let wasUserGesture = isUserGestureMoving
     refreshVisibleMarkers()
-    notifyRegionChange(complete: true)
-    endProgrammaticUpdate()
+    stopGestureMarkerRefresh()
+    handleRegionDidChange(wasUserGesture: wasUserGesture)
     notifyMapReadyIfNeeded()
   }
 

--- a/package/ios/HybridMapViewDelegate.swift
+++ b/package/ios/HybridMapViewDelegate.swift
@@ -80,14 +80,11 @@ final class HybridMapViewDelegate: NSObject, MKMapViewDelegate, UIGestureRecogni
   }
 
   func mapView(_ mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
-    parent?.startLiveClustering()
-    parent?.notifyRegionChange(complete: false)
+    parent?.handleRegionWillChange(userInteracting: mapView.isUserInteracting)
   }
 
   func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
-    parent?.stopLiveClustering()
-    parent?.notifyRegionChange(complete: true)
-    parent?.endProgrammaticRegionChangeIfNeeded()
+    parent?.handleRegionDidChange()
   }
 
   func mapViewDidFinishLoadingMap(_ mapView: MKMapView) {

--- a/package/ios/MKMapView+userInteraction.swift
+++ b/package/ios/MKMapView+userInteraction.swift
@@ -2,12 +2,16 @@ import MapKit
 
 extension MKMapView {
   var isUserInteracting: Bool {
-    guard let recognizers = subviews.first?.gestureRecognizers else {
-      return false
+    return hasActiveGestureRecognizer(in: self)
+  }
+
+  private func hasActiveGestureRecognizer(in view: UIView) -> Bool {
+    if let recognizers = view.gestureRecognizers,
+      recognizers.contains(where: { $0.state == .began || $0.state == .changed })
+    {
+      return true
     }
 
-    return recognizers.contains { recognizer in
-      recognizer.state == .began || recognizer.state == .changed
-    }
+    return view.subviews.contains { hasActiveGestureRecognizer(in: $0) }
   }
 }

--- a/package/ios/MKMapView+userInteraction.swift
+++ b/package/ios/MKMapView+userInteraction.swift
@@ -1,0 +1,13 @@
+import MapKit
+
+extension MKMapView {
+  var isUserInteracting: Bool {
+    guard let recognizers = subviews.first?.gestureRecognizers else {
+      return false
+    }
+
+    return recognizers.contains { recognizer in
+      recognizer.state == .began || recognizer.state == .changed
+    }
+  }
+}

--- a/package/ios/MapApproximateEquality.swift
+++ b/package/ios/MapApproximateEquality.swift
@@ -1,0 +1,9 @@
+import CoreLocation
+
+enum MapApproximateEquality {
+  static let coordinateEpsilon: Double = 1e-6
+  static let spanEpsilon: Double = 1e-6
+  static let zoomEpsilon: Float = 1e-4
+  static let angleEpsilon: CLLocationDirection = 1e-3
+  static let distanceEpsilon: Double = 0.1
+}

--- a/package/ios/Region+MKCoordinateRegion.swift
+++ b/package/ios/Region+MKCoordinateRegion.swift
@@ -10,6 +10,17 @@ extension Region {
 }
 
 extension MKCoordinateRegion {
+  func approximatelyEquals(
+    _ other: MKCoordinateRegion,
+    coordinateEpsilon: Double = MapApproximateEquality.coordinateEpsilon,
+    spanEpsilon: Double = MapApproximateEquality.spanEpsilon
+  ) -> Bool {
+    abs(center.latitude - other.center.latitude) < coordinateEpsilon
+      && abs(center.longitude - other.center.longitude) < coordinateEpsilon
+      && abs(span.latitudeDelta - other.span.latitudeDelta) < spanEpsilon
+      && abs(span.longitudeDelta - other.span.longitudeDelta) < spanEpsilon
+  }
+
   func toRegion() -> Region {
     Region(
       latitude: center.latitude,

--- a/package/src/native/specs/MapView.nitro.ts
+++ b/package/src/native/specs/MapView.nitro.ts
@@ -169,7 +169,7 @@ export interface MapViewProps extends HybridViewProps {
   /** Called once when a user-initiated region change begins. */
   onRegionChange?: (region: Region) => void;
 
-  /** Called when a region change animation completes. */
+  /** Called once when a user-initiated region change ends. */
   onRegionChangeComplete?: (region: Region) => void;
 
   /** Called when the map is ready to use. */

--- a/package/src/native/specs/MapView.nitro.ts
+++ b/package/src/native/specs/MapView.nitro.ts
@@ -166,7 +166,7 @@ export interface MapViewProps extends HybridViewProps {
   /** Entering animation for marker clusters. */
   clusterEnteringAnimation?: OverlayEnteringAnimationDescriptor;
 
-  /** Called when the visible region changes during user interaction. */
+  /** Called once when a user-initiated region change begins. */
   onRegionChange?: (region: Region) => void;
 
   /** Called when a region change animation completes. */

--- a/package/src/types/map.ts
+++ b/package/src/types/map.ts
@@ -102,7 +102,7 @@ interface BaseMapViewProps<PoiEvent extends PoiPressEvent = PoiPressEvent> {
   /** Called when any circle is pressed. */
   onCirclePress?: (id: string) => void;
 
-  /** Called when the map region changes after user interaction. */
+  /** Called once when a user-initiated region change begins. */
   onRegionChange?: (region: Region) => void;
 
   /** Called when the map region change completes. */

--- a/package/src/types/map.ts
+++ b/package/src/types/map.ts
@@ -105,7 +105,7 @@ interface BaseMapViewProps<PoiEvent extends PoiPressEvent = PoiPressEvent> {
   /** Called once when a user-initiated region change begins. */
   onRegionChange?: (region: Region) => void;
 
-  /** Called when the map region change completes. */
+  /** Called once when a user-initiated region change ends. */
   onRegionChangeComplete?: (region: Region) => void;
 
   /** Called when the map is ready to use. */


### PR DESCRIPTION
## Summary

Refactors how `onRegionChange` and `onRegionChangeComplete` are emitted across Apple Maps and Google Maps (iOS + Android).

- `onRegionChange` now fires **once** when a user-initiated region change **begins**
- `onRegionChangeComplete` fires **once** when the user gesture **ends**
- Programmatic camera/region updates (`setCamera`, `setRegion`, `fitToCoordinates`, etc.) no longer emit region change callbacks
- Removes the `isProgrammaticUpdate` flag machinery (counters, pending IDs, fallback timers) in favor of gesture-based detection
- Adds approximate equality checks before applying camera/region updates to skip no-op native updates caused by floating-point drift

## Breaking change

If consumers relied on `onRegionChange` / `onRegionChangeComplete` firing during programmatic camera animations, that behavior is removed. These callbacks are now user-gesture-only.

## Implementation details

**iOS (Apple Maps)**
- New `MKMapView.isUserInteracting` helper to detect active gesture recognizers
- `handleRegionWillChange` / `handleRegionDidChange` replace `notifyRegionChange` + programmatic update tracking

**iOS (Google Maps)**
- Uses `mapView(_:willMove:)` gesture flag
- Same handler pattern as Apple Maps

**Android (Google Maps)**
- Uses `OnCameraMoveStartedListener` with `REASON_GESTURE`
- Replaces `isProgrammaticUpdate` with `isUserGesture`

**Shared**
- `MapApproximateEquality` constants + `approximatelyEquals` on camera/region types (iOS + Android)

## Test plan

- [ ] Pan/zoom map with finger — `onRegionChange` fires once at start, `onRegionChangeComplete` once at end
- [ ] Call `setCamera` / `setRegion` from JS — no region change callbacks
- [ ] Call `fitToCoordinates` / `animateToRegion` — no region change callbacks
- [ ] Re-render with same `camera`/`region` props — native map does not jitter or re-apply
- [ ] Apple Maps: live clustering still starts/stops correctly during pan
- [ ] Google Maps (iOS): marker refresh during gesture still works
- [ ] Example app status bar updates coordinates on pan (new `onRegionChange` wiring)