### PR TITLE
docs: point npm homepage to GMI open-source page

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -68,7 +68,7 @@
   "bugs": {
     "url": "https://github.com/gmi-software/react-native-better-maps/issues"
   },
-  "homepage": "https://github.com/gmi-software/react-native-better-maps#readme",
+  "homepage": "https://gmi.software/open-source",
   "author": "gmi.software",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Updates the package metadata homepage so npm sends developer traffic to GMI's public open-source page.

- Changes only `package/package.json` homepage.
- Target: https://gmi.software/open-source
- Follow-up: publish a new package release after merge, then verify npm's Homepage link.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gmi-software/codesmith/react-native-better-maps/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787424163&installation_model_id=428715&pr_number=50&repository=gmi-software%2Freact-native-better-maps&return_to=https%3A%2F%2Fgithub.com%2Fgmi-software%2Freact-native-better-maps%2Fpull%2F50&signature=49b1fa19fe0b4831748bbf1387875f786270538e9cc776036e3e2301f09e76a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->