### PR TITLE
fix: refresh retained marker visuals across providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Additional props:
 | `anchor`       | `{ x: 0.5, y: 1 }` | Point on the image aligned to the coordinate        |
 | `centerOffset` | —                  | Extra offset in dp (MapKit-style)                   |
 | `rotation`     | `0`                | Clockwise rotation in degrees                       |
-| `flat`         | `false`            | Rotate with map plane (Google Maps; limited on iOS) |
+| `flat`         | `false`            | Rotate with map plane (Google Maps; MapKit approximates via view transform) |
 | `opacity`      | `1`                | Marker opacity from 0 to 1                          |
 
 Platform notes:

--- a/docs/adr/0004-custom-view-markers.md
+++ b/docs/adr/0004-custom-view-markers.md
@@ -109,9 +109,8 @@ natively — unlike the null-rendering `<Marker>`.
 
 ### Phase 0 — quick win (independent)
 
-- Fix the existing gap where iOS Google (`GoogleMapOverlayController.updateMarker`) sets
-  `icon = nil` and never applies `MarkerDescriptor.image`, so `<Marker image>` is
-  consistent across all three backends (MapKit, iOS Google, Android Google).
+Done: iOS Google applies `MarkerDescriptor` image, anchor, centerOffset, rotation, flat,
+and opacity so `<Marker image>` is consistent across MapKit, iOS Google, and Android Google.
 
 ### Phase 1 — MVP custom views (Option A)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,7 +91,7 @@ Delivered incrementally during Phases 3–5; polished for platform consistency i
 
 ## Custom view markers (ADR 0004)
 
-- [ ] Phase 0: apply `MarkerDescriptor.image` on iOS Google provider
+- [x] Phase 0: apply `MarkerDescriptor` image, anchor, centerOffset, rotation, flat, and opacity on iOS Google
 - [ ] Phase 1: `<Marker>` children via snapshot into existing image pipeline
 - [ ] Phase 2: `<MarkerView>` HybridView — live MapKit views, snapshot on Google
 

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -79,4 +79,5 @@ dependencies {
     implementation project(':react-native-nitro-modules')
     implementation 'com.google.android.gms:play-services-maps:19.0.0'
     implementation 'com.google.maps.android:android-maps-utils:3.8.2'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapOverlayController.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapOverlayController.kt
@@ -36,7 +36,7 @@ class MapOverlayController(
   private var onMarkerPress: ((String) -> Unit)? = null
   private var onClusterPress: ((List<String>, Coordinate) -> Unit)? = null
   private var allMarkerDescriptors: Array<MarkerDescriptor> = emptyArray()
-  private var markersFingerprint: Int = 0
+  private var markersFingerprint: Long = 0L
   private var spatialIndex: MarkerSpatialIndex? = null
   private var refreshGeneration: Int = 0
   private var viewWidthPx: Int = 0
@@ -103,7 +103,7 @@ class MapOverlayController(
     polygons.clear()
     circles.clear()
     allMarkerDescriptors = emptyArray()
-    markersFingerprint = 0
+    markersFingerprint = 0L
     spatialIndex = null
     refreshGeneration += 1
     computeExecutor.shutdown()
@@ -142,7 +142,6 @@ class MapOverlayController(
 
   fun refreshViewportMarkers(
     animateEntering: Boolean = true,
-    updateRetained: Boolean = true,
     maxAnimatedMarkers: Int = MAX_ANIMATED_MARKERS_PER_DIFF,
   ) {
     val map = googleMap ?: return
@@ -172,30 +171,13 @@ class MapOverlayController(
           .map { ClusterElement.Single(it) }
       }
 
-      val nextKeys = HashSet<String>(elements.size)
-      val added = ArrayList<ClusterElement>()
-      val retained = ArrayList<ClusterElement>()
-      for (element in elements) {
-        val key = element.diffKey
-        if (!nextKeys.add(key)) {
-          continue
-        }
-        val version = element.renderVersion
-        if (displayedVersions[key] != null) {
-          if (updateRetained && displayedVersions[key] != version) {
-            retained.add(element)
-          }
-        } else {
-          added.add(element)
-        }
-      }
-      val removed = displayedVersions.keys - nextKeys
+      val diff = computeMarkerRenderDiff(elements, displayedVersions)
 
       mainHandler.post {
         if (generation != refreshGeneration) {
           return@post
         }
-        applyDiff(removed, added, retained, animateEntering, maxAnimatedMarkers)
+        applyDiff(diff, animateEntering, maxAnimatedMarkers)
       }
     }
   }
@@ -218,15 +200,13 @@ class MapOverlayController(
   }
 
   private fun applyDiff(
-    removedKeys: Set<String>,
-    added: List<ClusterElement>,
-    retained: List<ClusterElement>,
+    diff: MarkerRenderDiff,
     animateEntering: Boolean = true,
     maxAnimatedMarkers: Int = MAX_ANIMATED_MARKERS_PER_DIFF,
   ) {
     val map = googleMap ?: return
 
-    for (key in removedKeys) {
+    for (key in diff.removedKeys) {
       cancelEnteringAnimation(key)
       markers.remove(key)?.remove()
       markerVersions.remove(key)
@@ -234,8 +214,8 @@ class MapOverlayController(
     }
 
     var remainingAnimationBudget = maxAnimatedMarkers.coerceAtLeast(0)
-    val addedMarkers = ArrayList<AddedMarker>(minOf(added.size, remainingAnimationBudget))
-    for (element in added) {
+    val addedMarkers = ArrayList<AddedMarker>(minOf(diff.added.size, remainingAnimationBudget))
+    for (element in diff.added) {
       val key = element.diffKey
       when (element) {
         is ClusterElement.Single -> {
@@ -253,7 +233,8 @@ class MapOverlayController(
             markerIconFactory.applyVisualProps(element.descriptor, marker, key)
             markerVersions[key] = element.renderVersion
             if (shouldAnimate) {
-              addedMarkers.add(AddedMarker(key, marker, animation))
+              val targetAlpha = element.descriptor.opacity?.toFloat() ?: 1f
+              addedMarkers.add(AddedMarker(key, marker, animation, targetAlpha))
               remainingAnimationBudget -= 1
             }
           }
@@ -276,7 +257,7 @@ class MapOverlayController(
             markerVersions[key] = element.renderVersion
             clusterByKey[key] = element
             if (shouldAnimate) {
-              addedMarkers.add(AddedMarker(key, marker, animation))
+              addedMarkers.add(AddedMarker(key, marker, animation, targetAlpha = 1f))
               remainingAnimationBudget -= 1
             }
           }
@@ -284,11 +265,10 @@ class MapOverlayController(
       }
     }
 
-    for (element in retained) {
+    for (element in diff.retained) {
       val key = element.diffKey
       val marker = markers[key] ?: continue
       cancelEnteringAnimation(key)
-      marker.alpha = 1f
       when (element) {
         is ClusterElement.Single -> {
           marker.tag = element.descriptor.id
@@ -303,6 +283,7 @@ class MapOverlayController(
           clusterByKey.remove(key)
         }
         is ClusterElement.Cluster -> {
+          marker.alpha = 1f
           marker.position = element.position
           marker.setIcon(iconFactory.icon(element.count))
           clusterByKey[key] = element
@@ -348,7 +329,7 @@ class MapOverlayController(
           val localElapsed = elapsed - (animatedMarker.animation.delayMs - startDelay)
           val progress = (localElapsed.toFloat() / animatedMarker.animation.durationMs.toFloat())
             .coerceIn(0f, 1f)
-          animatedMarker.marker.alpha = progress
+          animatedMarker.marker.alpha = progress * animatedMarker.targetAlpha
         }
       }
       addListener(object : AnimatorListenerAdapter() {
@@ -369,7 +350,7 @@ class MapOverlayController(
 
   private fun revealAnimatedMarkers(animated: List<AddedMarker>) {
     animated.forEach { animatedMarker ->
-      animatedMarker.marker.alpha = 1f
+      animatedMarker.marker.alpha = animatedMarker.targetAlpha
     }
   }
 
@@ -422,14 +403,14 @@ class MapOverlayController(
           markers[key] = marker
           markerIconFactory.applyVisualProps(descriptor, marker, key)
           markerVersions[key] = element.renderVersion
-          animateEntering(listOf(AddedMarker(key, marker, animation)))
+          val targetAlpha = descriptor.opacity?.toFloat() ?: 1f
+          animateEntering(listOf(AddedMarker(key, marker, animation, targetAlpha)))
         }
       },
       update = { marker, descriptor ->
         val element = ClusterElement.Single(descriptor)
         val key = "s:" + descriptor.id
         (marker.tag as? String)?.let { cancelEnteringAnimation(it) }
-        marker.alpha = 1f
         marker.tag = descriptor.id
         marker.position = LatLng(
           descriptor.coordinate.latitude,
@@ -495,7 +476,6 @@ class MapOverlayController(
     if (usesViewportPipeline()) {
       refreshViewportMarkers(
         animateEntering = true,
-        updateRetained = true,
         maxAnimatedMarkers = MAX_LIVE_ANIMATED_MARKERS_PER_DIFF,
       )
     }
@@ -640,5 +620,6 @@ class MapOverlayController(
     val key: String,
     val marker: Marker,
     val animation: ResolvedOverlayEnteringAnimation,
+    val targetAlpha: Float,
   )
 }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerClusterEngine.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerClusterEngine.kt
@@ -14,16 +14,7 @@ internal sealed interface ClusterElement {
 
   data class Single(val descriptor: MarkerDescriptor) : ClusterElement {
     override val diffKey: String get() = "s:" + descriptor.id
-    override val renderVersion: Long = renderSignature(
-      "single",
-      descriptor.id,
-      descriptor.coordinate.latitude,
-      descriptor.coordinate.longitude,
-      descriptor.title,
-      descriptor.subtitle,
-      descriptor.draggable,
-      descriptor.clusterable,
-    )
+    override val renderVersion: Long = descriptor.displayedIdentityVersion()
   }
 
   data class Cluster(
@@ -47,14 +38,6 @@ internal sealed interface ClusterElement {
       bounds.northeast.longitude,
     )
   }
-}
-
-private fun renderSignature(vararg parts: Any?): Long {
-  var hash = -3750763034362895579L
-  for (part in parts) {
-    hash = 1099511628211L * hash + (part?.hashCode()?.toLong() ?: 0L)
-  }
-  return hash
 }
 
 /**

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerDescriptor+DisplayedIdentity.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerDescriptor+DisplayedIdentity.kt
@@ -1,0 +1,24 @@
+package com.margelo.nitro.nitromaps
+
+/** Displayed-marker identity. Omits `enteringAnimation`; keep in sync with the Swift hasher. */
+internal fun MarkerDescriptor.displayedIdentityVersion(): Long =
+  renderSignature(
+    id,
+    coordinate.latitude,
+    coordinate.longitude,
+    title,
+    subtitle,
+    draggable,
+    clusterable,
+    image?.uri,
+    image?.width,
+    image?.height,
+    image?.scale,
+    anchor?.x,
+    anchor?.y,
+    centerOffset?.x,
+    centerOffset?.y,
+    rotation,
+    flat,
+    opacity,
+  )

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerDescriptor+Fingerprint.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerDescriptor+Fingerprint.kt
@@ -1,13 +1,22 @@
 package com.margelo.nitro.nitromaps
 
-internal fun Array<MarkerDescriptor>?.markersFingerprint(): Int {
+internal fun MarkerDescriptor.fingerprint(): Long =
+  renderSignature(
+    displayedIdentityVersion(),
+    enteringAnimation?.kind,
+    enteringAnimation?.duration,
+    enteringAnimation?.delay,
+    enteringAnimation?.reduceMotion,
+  )
+
+internal fun Array<MarkerDescriptor>?.markersFingerprint(): Long {
   if (this.isNullOrEmpty()) {
-    return 0
+    return 0L
   }
 
-  var hash = size
+  var hash = size.toLong()
   for (descriptor in this) {
-    hash = 31 * hash + descriptor.hashCode()
+    hash = 31L * hash + descriptor.fingerprint()
   }
   return hash
 }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerRenderDiff.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MarkerRenderDiff.kt
@@ -1,0 +1,35 @@
+package com.margelo.nitro.nitromaps
+
+internal data class MarkerRenderDiff(
+  val removedKeys: Set<String>,
+  val added: List<ClusterElement>,
+  val retained: List<ClusterElement>,
+)
+
+internal fun computeMarkerRenderDiff(
+  target: List<ClusterElement>,
+  displayed: Map<String, Long>,
+): MarkerRenderDiff {
+  val nextKeys = HashSet<String>(target.size)
+  val added = ArrayList<ClusterElement>()
+  val retained = ArrayList<ClusterElement>()
+
+  for (element in target) {
+    val key = element.diffKey
+    if (!nextKeys.add(key)) {
+      continue
+    }
+    val displayedVersion = displayed[key]
+    if (displayedVersion == null) {
+      added.add(element)
+    } else if (displayedVersion != element.renderVersion) {
+      retained.add(element)
+    }
+  }
+
+  return MarkerRenderDiff(
+    removedKeys = displayed.keys - nextKeys,
+    added = added,
+    retained = retained,
+  )
+}

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/RenderSignature.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/RenderSignature.kt
@@ -1,0 +1,16 @@
+package com.margelo.nitro.nitromaps
+
+/**
+ * Absent values hash outside the `Int` range so no present value can collide with them.
+ * Without this, `null` and `0.0` are indistinguishable, because `0.0.hashCode() == 0`.
+ */
+private const val ABSENT_HASH = 0x1_0000_0000L
+
+/** Stable fold over the given parts, used to version render state for diffing. */
+internal fun renderSignature(vararg parts: Any?): Long {
+  var hash = -3750763034362895579L
+  for (part in parts) {
+    hash = 1099511628211L * hash + (part?.hashCode()?.toLong() ?: ABSENT_HASH)
+  }
+  return hash
+}

--- a/package/android/src/test/java/com/margelo/nitro/nitromaps/MarkerDescriptorFixture.kt
+++ b/package/android/src/test/java/com/margelo/nitro/nitromaps/MarkerDescriptorFixture.kt
@@ -1,0 +1,28 @@
+package com.margelo.nitro.nitromaps
+
+internal fun marker(
+  id: String = "marker-1",
+  image: MarkerImage? = null,
+  anchor: MarkerAnchor? = null,
+  centerOffset: MarkerPoint? = null,
+  rotation: Double? = null,
+  flat: Boolean? = null,
+  opacity: Double? = null,
+  enteringAnimation: OverlayEnteringAnimationDescriptor? = null,
+): MarkerDescriptor {
+  return MarkerDescriptor(
+    id,
+    Coordinate(37.77, -122.41),
+    "Title",
+    "Subtitle",
+    false,
+    true,
+    image,
+    anchor,
+    centerOffset,
+    rotation,
+    flat,
+    opacity,
+    enteringAnimation,
+  )
+}

--- a/package/android/src/test/java/com/margelo/nitro/nitromaps/MarkerDisplayedIdentityTest.kt
+++ b/package/android/src/test/java/com/margelo/nitro/nitromaps/MarkerDisplayedIdentityTest.kt
@@ -1,0 +1,119 @@
+package com.margelo.nitro.nitromaps
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkerDisplayedIdentityTest {
+  @Test
+  fun `visual field changes update displayed identity`() {
+    val pairs = listOf(
+      "image" to (
+        marker(image = MarkerImage("asset:/pin.png", 32.0, 32.0, 2.0)) to
+          marker(image = MarkerImage("asset:/pin-alt.png", 32.0, 32.0, 2.0))
+        ),
+      "rotation" to (marker(rotation = 0.0) to marker(rotation = 45.0)),
+      "opacity" to (marker(opacity = 1.0) to marker(opacity = 0.4)),
+      "anchor" to (
+        marker(anchor = MarkerAnchor(0.5, 1.0)) to marker(anchor = MarkerAnchor(0.5, 0.5))
+        ),
+      "centerOffset" to (
+        marker(centerOffset = MarkerPoint(0.0, 0.0)) to
+          marker(centerOffset = MarkerPoint(4.0, -8.0))
+        ),
+      "flat" to (marker(flat = false) to marker(flat = true)),
+    )
+
+    for ((field, pair) in pairs) {
+      val (before, after) = pair
+      assertNotEquals(field, before.displayedIdentityVersion(), after.displayedIdentityVersion())
+    }
+  }
+
+  @Test
+  fun `absent fields are distinguishable from zero valued ones`() {
+    assertNotEquals(
+      "opacity",
+      marker(opacity = null).displayedIdentityVersion(),
+      marker(opacity = 0.0).displayedIdentityVersion(),
+    )
+    assertNotEquals(
+      "anchor",
+      marker(anchor = null).displayedIdentityVersion(),
+      marker(anchor = MarkerAnchor(0.0, 0.0)).displayedIdentityVersion(),
+    )
+    assertNotEquals(
+      "opacity fingerprint",
+      arrayOf(marker(opacity = null)).markersFingerprint(),
+      arrayOf(marker(opacity = 0.0)).markersFingerprint(),
+    )
+  }
+
+  @Test
+  fun `entering animation change does not update displayed identity`() {
+    val before = marker(
+      enteringAnimation = OverlayEnteringAnimationDescriptor(
+        OverlayEnteringAnimationKind.FADE,
+        200.0,
+        0.0,
+        OverlayEnteringAnimationReduceMotion.SYSTEM,
+      ),
+    )
+    val after = marker(
+      enteringAnimation = OverlayEnteringAnimationDescriptor(
+        OverlayEnteringAnimationKind.NONE,
+        400.0,
+        50.0,
+        OverlayEnteringAnimationReduceMotion.NEVER,
+      ),
+    )
+
+    assertEquals(before.displayedIdentityVersion(), after.displayedIdentityVersion())
+    assertNotEquals(before.fingerprint(), after.fingerprint())
+  }
+
+  @Test
+  fun `displayed identity change reaches retained list`() {
+    val displayed = ClusterElement.Single(marker(opacity = 1.0))
+    val next = ClusterElement.Single(marker(opacity = 0.2))
+    val diff = computeMarkerRenderDiff(
+      listOf(next),
+      mapOf(displayed.diffKey to displayed.renderVersion),
+    )
+
+    assertEquals(listOf(next), diff.retained)
+  }
+
+  @Test
+  fun `entering animation change does not reach retained list`() {
+    val displayed = ClusterElement.Single(
+      marker(
+        enteringAnimation = OverlayEnteringAnimationDescriptor(
+          OverlayEnteringAnimationKind.FADE,
+          200.0,
+          null,
+          null,
+        ),
+      ),
+    )
+    val next = ClusterElement.Single(
+      marker(
+        enteringAnimation = OverlayEnteringAnimationDescriptor(
+          OverlayEnteringAnimationKind.NONE,
+          400.0,
+          null,
+          null,
+        ),
+      ),
+    )
+    val diff = computeMarkerRenderDiff(
+      listOf(next),
+      mapOf(displayed.diffKey to displayed.renderVersion),
+    )
+
+    assertTrue(diff.retained.isEmpty())
+    assertTrue(diff.added.isEmpty())
+    assertTrue(diff.removedKeys.isEmpty())
+  }
+}

--- a/package/android/src/test/java/com/margelo/nitro/nitromaps/MarkerRenderDiffTest.kt
+++ b/package/android/src/test/java/com/margelo/nitro/nitromaps/MarkerRenderDiffTest.kt
@@ -1,0 +1,67 @@
+package com.margelo.nitro.nitromaps
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkerRenderDiffTest {
+  @Test
+  fun `new keys are added`() {
+    val first = ClusterElement.Single(marker(id = "a"))
+    val second = ClusterElement.Single(marker(id = "b"))
+    val diff = computeMarkerRenderDiff(listOf(first, second), emptyMap())
+
+    assertEquals(emptySet<String>(), diff.removedKeys)
+    assertEquals(listOf(first, second), diff.added)
+    assertTrue(diff.retained.isEmpty())
+  }
+
+  @Test
+  fun `missing keys are removed`() {
+    val kept = ClusterElement.Single(marker(id = "a"))
+    val diff = computeMarkerRenderDiff(
+      listOf(kept),
+      mapOf("s:a" to kept.renderVersion, "s:gone" to 9L),
+    )
+
+    assertEquals(setOf("s:gone"), diff.removedKeys)
+    assertTrue(diff.added.isEmpty())
+    assertTrue(diff.retained.isEmpty())
+  }
+
+  @Test
+  fun `version change marks retained`() {
+    val displayed = ClusterElement.Single(marker(id = "a", opacity = 1.0))
+    val next = ClusterElement.Single(marker(id = "a", opacity = 0.2))
+    val diff = computeMarkerRenderDiff(
+      listOf(next),
+      mapOf(displayed.diffKey to displayed.renderVersion),
+    )
+
+    assertTrue(diff.removedKeys.isEmpty())
+    assertTrue(diff.added.isEmpty())
+    assertEquals(listOf(next), diff.retained)
+  }
+
+  @Test
+  fun `unchanged version is skipped`() {
+    val element = ClusterElement.Single(marker(id = "a"))
+    val diff = computeMarkerRenderDiff(
+      listOf(element),
+      mapOf(element.diffKey to element.renderVersion),
+    )
+
+    assertTrue(diff.removedKeys.isEmpty())
+    assertTrue(diff.added.isEmpty())
+    assertTrue(diff.retained.isEmpty())
+  }
+
+  @Test
+  fun `duplicate keys keep the first element`() {
+    val first = ClusterElement.Single(marker(id = "a", opacity = 1.0))
+    val duplicate = ClusterElement.Single(marker(id = "a", opacity = 0.1))
+    val diff = computeMarkerRenderDiff(listOf(first, duplicate), emptyMap())
+
+    assertEquals(listOf(first), diff.added)
+  }
+}

--- a/package/ios/GoogleMapOverlayController.swift
+++ b/package/ios/GoogleMapOverlayController.swift
@@ -2,6 +2,7 @@ import GoogleMaps
 import MapKit
 import UIKit
 
+/// Reconciles overlay descriptors with Google Maps objects.
 final class GoogleMapOverlayController {
   private static let clusterCellPoints: Double = 96
   // GMSMarker entering animations are main-thread work; cap them per diff so
@@ -25,6 +26,7 @@ final class GoogleMapOverlayController {
   private var polygons: [String: GMSPolygon] = [:]
   private var circles: [String: GMSCircle] = [:]
   private let markerPipeline: MarkerRenderPipeline
+  private let visualApplier = GoogleMarkerVisualApplier()
   private var clusterIconCache: [String: UIImage] = [:]
 
   var onMarkerPress: ((String) -> Void)?
@@ -214,7 +216,8 @@ final class GoogleMapOverlayController {
     var remainingAnimationBudget = animateEntering ? max(0, animationBudget) : 0
 
     for entry in diff.added {
-      let marker = makeMarker(for: entry.element)
+      let marker = GMSMarker()
+      updateMarker(marker, with: entry.element)
       let animation = enteringAnimation(for: entry.element)
       let shouldAnimate = animateEntering
         && remainingAnimationBudget > 0
@@ -245,12 +248,6 @@ final class GoogleMapOverlayController {
       updateMarker(marker, with: entry.element)
       markerVersions[entry.key] = entry.version
     }
-  }
-
-  private func makeMarker(for element: MarkerClusterEngine.Element) -> GMSMarker {
-    let marker = GMSMarker()
-    updateMarker(marker, with: element)
-    return marker
   }
 
   private func append(
@@ -286,9 +283,8 @@ final class GoogleMapOverlayController {
       marker.title = descriptor.title
       marker.snippet = descriptor.subtitle
       marker.isDraggable = descriptor.draggable == true
-      marker.icon = nil
-      marker.groundAnchor = CGPoint(x: 0.5, y: 1)
       marker.userData = MarkerPayload.marker(descriptor.id)
+      visualApplier.apply(descriptor, to: marker)
     case let .cluster(_, coordinate, count, memberIds, region):
       marker.position = coordinate
       marker.title = nil

--- a/package/ios/GoogleMarkerVisualApplier.swift
+++ b/package/ios/GoogleMarkerVisualApplier.swift
@@ -6,52 +6,98 @@ final class GoogleMarkerVisualApplier {
   private static let defaultIconToken: NSString = "__default__"
   private static let defaultPinImage = GMSMarker.markerImage(with: nil)
 
-  private let appliedTokens = NSMapTable<GMSMarker, NSString>.weakToStrongObjects()
-  private let pendingTokens = NSMapTable<GMSMarker, NSString>.weakToStrongObjects()
+  private struct PendingIconLoad {
+    let imageToken: NSString
+    var descriptor: MarkerDescriptor
+  }
+
+  private final class MarkerIconState: NSObject {
+    var appliedImageToken: NSString?
+    var loadGeneration = 0
+    var pending: PendingIconLoad?
+  }
+
+  private let states = NSMapTable<GMSMarker, MarkerIconState>.weakToStrongObjects()
+  private let cachedImage: (MarkerImage) -> UIImage?
+  private let loadImage: (MarkerImage, @escaping (UIImage?) -> Void) -> Void
+
+  init(
+    cachedImage: @escaping (MarkerImage) -> UIImage? = MarkerImageLoader.cachedImage(for:),
+    loadImage: @escaping (MarkerImage, @escaping (UIImage?) -> Void) -> Void = {
+      MarkerImageLoader.load($0, completion: $1)
+    }
+  ) {
+    self.cachedImage = cachedImage
+    self.loadImage = loadImage
+  }
 
   func apply(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
     marker.rotation = descriptor.rotation ?? 0
     marker.isFlat = descriptor.flat == true
     marker.opacity = Float(descriptor.opacity ?? 1)
+    applyAnchor(descriptor, to: marker)
     applyIcon(descriptor, to: marker)
   }
 
+  private func applyAnchor(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
+    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(
+      imageSize: anchorImageSize(descriptor, icon: marker.icon)
+    )
+  }
+
   private func applyIcon(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
+    let state = state(for: marker)
+
     guard let image = descriptor.image else {
-      pendingTokens.removeObject(forKey: marker)
-      if appliedTokens.object(forKey: marker) != Self.defaultIconToken {
+      cancelPending(state)
+      if state.appliedImageToken != Self.defaultIconToken {
         marker.icon = nil
-        appliedTokens.setObject(Self.defaultIconToken, forKey: marker)
+        state.appliedImageToken = Self.defaultIconToken
       }
-      marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(
-        imageSize: Self.defaultPinImage.size
-      )
       return
     }
 
-    let token = MarkerImageLoader.cacheKey(for: image)
-    if appliedTokens.object(forKey: marker) == token, let icon = marker.icon {
-      marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: icon.size)
+    let imageToken = MarkerImageLoader.cacheKey(for: image)
+    if state.appliedImageToken == imageToken, marker.icon != nil {
+      if state.pending != nil {
+        cancelPending(state)
+      }
       return
     }
 
-    if let cached = MarkerImageLoader.cachedImage(for: image) {
-      pendingTokens.removeObject(forKey: marker)
-      setIcon(cached, token: token, on: marker, descriptor: descriptor)
+    if var pending = state.pending, pending.imageToken == imageToken {
+      pending.descriptor = descriptor
+      state.pending = pending
       return
     }
 
-    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: .zero)
-    pendingTokens.setObject(token, forKey: marker)
-    MarkerImageLoader.load(image) { [weak self, weak marker] uiImage in
-      guard let self, let marker, self.pendingTokens.object(forKey: marker) == token else {
+    if let cached = cachedImage(image) {
+      cancelPending(state)
+      setIcon(cached, token: imageToken, on: marker, descriptor: descriptor, state: state)
+      return
+    }
+
+    cancelPending(state)
+    let generation = state.loadGeneration
+    state.pending = PendingIconLoad(imageToken: imageToken, descriptor: descriptor)
+    loadImage(image) { [weak self, weak marker] uiImage in
+      guard let self, let marker, let state = self.states.object(forKey: marker) else {
         return
       }
-      self.pendingTokens.removeObject(forKey: marker)
+      guard state.loadGeneration == generation, let pending = state.pending else {
+        return
+      }
+      state.pending = nil
       guard let uiImage else {
         return
       }
-      self.setIcon(uiImage, token: token, on: marker, descriptor: descriptor)
+      self.setIcon(
+        uiImage,
+        token: pending.imageToken,
+        on: marker,
+        descriptor: pending.descriptor,
+        state: state
+      )
     }
   }
 
@@ -59,10 +105,40 @@ final class GoogleMarkerVisualApplier {
     _ uiImage: UIImage,
     token: NSString,
     on marker: GMSMarker,
-    descriptor: MarkerDescriptor
+    descriptor: MarkerDescriptor,
+    state: MarkerIconState
   ) {
     marker.icon = uiImage
-    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: uiImage.size)
-    appliedTokens.setObject(token, forKey: marker)
+    applyAnchor(descriptor, to: marker)
+    state.appliedImageToken = token
+  }
+
+  private func state(for marker: GMSMarker) -> MarkerIconState {
+    if let existing = states.object(forKey: marker) {
+      return existing
+    }
+    let created = MarkerIconState()
+    states.setObject(created, forKey: marker)
+    return created
+  }
+
+  private func cancelPending(_ state: MarkerIconState) {
+    state.loadGeneration += 1
+    state.pending = nil
+  }
+
+  private func anchorImageSize(_ descriptor: MarkerDescriptor, icon: UIImage?) -> CGSize {
+    if let image = descriptor.image, let width = image.width, let height = image.height,
+       width > 0, height > 0
+    {
+      return CGSize(width: width, height: height)
+    }
+    if descriptor.image == nil {
+      return Self.defaultPinImage.size
+    }
+    if let icon, icon.size.width > 0, icon.size.height > 0 {
+      return icon.size
+    }
+    return Self.defaultPinImage.size
   }
 }

--- a/package/ios/GoogleMarkerVisualApplier.swift
+++ b/package/ios/GoogleMarkerVisualApplier.swift
@@ -7,13 +7,13 @@ final class GoogleMarkerVisualApplier {
   private static let defaultPinImage = GMSMarker.markerImage(with: nil)
 
   private struct PendingIconLoad {
+    let applicationToken: NSObject
     let imageToken: NSString
-    var descriptor: MarkerDescriptor
+    let descriptor: MarkerDescriptor
   }
 
   private final class MarkerIconState: NSObject {
     var appliedImageToken: NSString?
-    var loadGeneration = 0
     var pending: PendingIconLoad?
   }
 
@@ -65,12 +65,6 @@ final class GoogleMarkerVisualApplier {
       return
     }
 
-    if var pending = state.pending, pending.imageToken == imageToken {
-      pending.descriptor = descriptor
-      state.pending = pending
-      return
-    }
-
     if let cached = cachedImage(image) {
       cancelPending(state)
       setIcon(cached, token: imageToken, on: marker, descriptor: descriptor, state: state)
@@ -78,13 +72,19 @@ final class GoogleMarkerVisualApplier {
     }
 
     cancelPending(state)
-    let generation = state.loadGeneration
-    state.pending = PendingIconLoad(imageToken: imageToken, descriptor: descriptor)
+    let applicationToken = NSObject()
+    state.pending = PendingIconLoad(
+      applicationToken: applicationToken,
+      imageToken: imageToken,
+      descriptor: descriptor
+    )
     loadImage(image) { [weak self, weak marker] uiImage in
       guard let self, let marker, let state = self.states.object(forKey: marker) else {
         return
       }
-      guard state.loadGeneration == generation, let pending = state.pending else {
+      guard let pending = state.pending,
+            pending.applicationToken === applicationToken
+      else {
         return
       }
       state.pending = nil
@@ -123,7 +123,6 @@ final class GoogleMarkerVisualApplier {
   }
 
   private func cancelPending(_ state: MarkerIconState) {
-    state.loadGeneration += 1
     state.pending = nil
   }
 

--- a/package/ios/GoogleMarkerVisualApplier.swift
+++ b/package/ios/GoogleMarkerVisualApplier.swift
@@ -1,0 +1,68 @@
+import GoogleMaps
+import UIKit
+
+/// Applies a marker descriptor's visual fields onto a `GMSMarker`. Main-thread only.
+final class GoogleMarkerVisualApplier {
+  private static let defaultIconToken: NSString = "__default__"
+  private static let defaultPinImage = GMSMarker.markerImage(with: nil)
+
+  private let appliedTokens = NSMapTable<GMSMarker, NSString>.weakToStrongObjects()
+  private let pendingTokens = NSMapTable<GMSMarker, NSString>.weakToStrongObjects()
+
+  func apply(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
+    marker.rotation = descriptor.rotation ?? 0
+    marker.isFlat = descriptor.flat == true
+    marker.opacity = Float(descriptor.opacity ?? 1)
+    applyIcon(descriptor, to: marker)
+  }
+
+  private func applyIcon(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
+    guard let image = descriptor.image else {
+      pendingTokens.removeObject(forKey: marker)
+      if appliedTokens.object(forKey: marker) != Self.defaultIconToken {
+        marker.icon = nil
+        appliedTokens.setObject(Self.defaultIconToken, forKey: marker)
+      }
+      marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(
+        imageSize: Self.defaultPinImage.size
+      )
+      return
+    }
+
+    let token = MarkerImageLoader.cacheKey(for: image)
+    if appliedTokens.object(forKey: marker) == token, let icon = marker.icon {
+      marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: icon.size)
+      return
+    }
+
+    if let cached = MarkerImageLoader.cachedImage(for: image) {
+      pendingTokens.removeObject(forKey: marker)
+      setIcon(cached, token: token, on: marker, descriptor: descriptor)
+      return
+    }
+
+    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: .zero)
+    pendingTokens.setObject(token, forKey: marker)
+    MarkerImageLoader.load(image) { [weak self, weak marker] uiImage in
+      guard let self, let marker, self.pendingTokens.object(forKey: marker) == token else {
+        return
+      }
+      self.pendingTokens.removeObject(forKey: marker)
+      guard let uiImage else {
+        return
+      }
+      self.setIcon(uiImage, token: token, on: marker, descriptor: descriptor)
+    }
+  }
+
+  private func setIcon(
+    _ uiImage: UIImage,
+    token: NSString,
+    on marker: GMSMarker,
+    descriptor: MarkerDescriptor
+  ) {
+    marker.icon = uiImage
+    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: uiImage.size)
+    appliedTokens.setObject(token, forKey: marker)
+  }
+}

--- a/package/ios/MarkerClusterEngine.swift
+++ b/package/ios/MarkerClusterEngine.swift
@@ -29,18 +29,11 @@ enum MarkerClusterEngine {
     }
 
     var renderVersion: Int {
-      var hasher = Hasher()
       switch self {
       case let .single(descriptor):
-        hasher.combine("single")
-        hasher.combine(descriptor.id)
-        hasher.combine(descriptor.coordinate.latitude)
-        hasher.combine(descriptor.coordinate.longitude)
-        hasher.combine(descriptor.title)
-        hasher.combine(descriptor.subtitle)
-        hasher.combine(descriptor.draggable)
-        hasher.combine(descriptor.clusterable)
+        return descriptor.displayedIdentityVersion()
       case let .cluster(key, coordinate, count, memberIds, region):
+        var hasher = Hasher()
         hasher.combine("cluster")
         hasher.combine(key)
         hasher.combine(coordinate.latitude)
@@ -53,8 +46,8 @@ enum MarkerClusterEngine {
         hasher.combine(region.center.longitude)
         hasher.combine(region.span.latitudeDelta)
         hasher.combine(region.span.longitudeDelta)
+        return hasher.finalize()
       }
-      return hasher.finalize()
     }
 
     func makeAnnotation(

--- a/package/ios/MarkerDescriptor+Fingerprint.swift
+++ b/package/ios/MarkerDescriptor+Fingerprint.swift
@@ -1,62 +1,40 @@
 extension MarkerDescriptor {
-  func markersDescriptorFingerprint() -> Int {
-    var hasher = Hasher()
+  /// Combines optionals as-is so `nil` stays distinguishable from a present value.
+  private func hashDisplayedIdentity(into hasher: inout Hasher) {
     hasher.combine(id)
     hasher.combine(coordinate.latitude)
     hasher.combine(coordinate.longitude)
-    if let title {
-      hasher.combine(title)
-    }
-    if let subtitle {
-      hasher.combine(subtitle)
-    }
-    if let draggable {
-      hasher.combine(draggable)
-    }
-    if let clusterable {
-      hasher.combine(clusterable)
-    }
-    if let image {
-      hasher.combine(image.uri)
-      if let width = image.width {
-        hasher.combine(width)
-      }
-      if let height = image.height {
-        hasher.combine(height)
-      }
-      if let scale = image.scale {
-        hasher.combine(scale)
-      }
-    }
-    if let anchor {
-      hasher.combine(anchor.x)
-      hasher.combine(anchor.y)
-    }
-    if let centerOffset {
-      hasher.combine(centerOffset.x)
-      hasher.combine(centerOffset.y)
-    }
-    if let rotation {
-      hasher.combine(rotation)
-    }
-    if let flat {
-      hasher.combine(flat)
-    }
-    if let opacity {
-      hasher.combine(opacity)
-    }
-    if let enteringAnimation {
-      hasher.combine(enteringAnimation.kind)
-      if let duration = enteringAnimation.duration {
-        hasher.combine(duration)
-      }
-      if let delay = enteringAnimation.delay {
-        hasher.combine(delay)
-      }
-      if let reduceMotion = enteringAnimation.reduceMotion {
-        hasher.combine(reduceMotion)
-      }
-    }
+    hasher.combine(title)
+    hasher.combine(subtitle)
+    hasher.combine(draggable)
+    hasher.combine(clusterable)
+    hasher.combine(image?.uri)
+    hasher.combine(image?.width)
+    hasher.combine(image?.height)
+    hasher.combine(image?.scale)
+    hasher.combine(anchor?.x)
+    hasher.combine(anchor?.y)
+    hasher.combine(centerOffset?.x)
+    hasher.combine(centerOffset?.y)
+    hasher.combine(rotation)
+    hasher.combine(flat)
+    hasher.combine(opacity)
+  }
+
+  func markersDescriptorFingerprint() -> Int {
+    var hasher = Hasher()
+    hashDisplayedIdentity(into: &hasher)
+    hasher.combine(enteringAnimation?.kind)
+    hasher.combine(enteringAnimation?.duration)
+    hasher.combine(enteringAnimation?.delay)
+    hasher.combine(enteringAnimation?.reduceMotion)
+    return hasher.finalize()
+  }
+
+  /// Displayed-marker identity. Omits `enteringAnimation`; retained updates skip it.
+  func displayedIdentityVersion() -> Int {
+    var hasher = Hasher()
+    hashDisplayedIdentity(into: &hasher)
     return hasher.finalize()
   }
 }

--- a/package/ios/MarkerDescriptor+GoogleMapsAnchor.swift
+++ b/package/ios/MarkerDescriptor+GoogleMapsAnchor.swift
@@ -1,0 +1,18 @@
+import CoreGraphics
+
+extension MarkerDescriptor {
+  func effectiveGoogleMapsAnchor(imageSize: CGSize) -> CGPoint {
+    let anchorX = anchor?.x ?? 0.5
+    let anchorY = anchor?.y ?? 1.0
+    guard imageSize.width > 0, imageSize.height > 0 else {
+      return CGPoint(x: anchorX, y: anchorY)
+    }
+
+    let offsetX = centerOffset?.x ?? 0
+    let offsetY = centerOffset?.y ?? 0
+    return CGPoint(
+      x: anchorX - offsetX / imageSize.width,
+      y: anchorY - offsetY / imageSize.height
+    )
+  }
+}

--- a/package/ios/MarkerImageLoader.swift
+++ b/package/ios/MarkerImageLoader.swift
@@ -1,9 +1,18 @@
 import UIKit
 
 /// Loads marker images from bundled assets or remote URLs with in-memory caching.
+/// Local images decode off-thread; completions always land on main.
 enum MarkerImageLoader {
   private static let cache = NSCache<NSString, UIImage>()
   private static let session = URLSession.shared
+  private static let decodeQueue = DispatchQueue(
+    label: "com.nitromaps.markerImageDecode",
+    qos: .userInitiated
+  )
+
+  static func cachedImage(for image: MarkerImage) -> UIImage? {
+    cache.object(forKey: cacheKey(for: image))
+  }
 
   static func load(
     _ image: MarkerImage,
@@ -21,13 +30,15 @@ enum MarkerImageLoader {
       return
     }
 
-    if let loaded = loadLocal(uri: uri, image: image) {
-      cache.setObject(loaded, forKey: cacheKey)
-      completion(loaded)
-      return
+    decodeQueue.async {
+      let loaded = loadLocal(uri: uri, image: image)
+      if let loaded {
+        cache.setObject(loaded, forKey: cacheKey)
+      }
+      DispatchQueue.main.async {
+        completion(loaded)
+      }
     }
-
-    completion(nil)
   }
 
   static func cacheKey(for image: MarkerImage) -> NSString {

--- a/package/ios/OverlayEnteringAnimation.swift
+++ b/package/ios/OverlayEnteringAnimation.swift
@@ -112,7 +112,6 @@ enum OverlayEnteringAnimationResolver {
     marker.appearAnimation = .none
     marker.iconView = nil
     marker.tracksViewChanges = false
-    marker.opacity = 1
   }
 
   static func animateGoogleMarkers(

--- a/package/iosTests/GoogleMarkerVisualApplierTests.swift
+++ b/package/iosTests/GoogleMarkerVisualApplierTests.swift
@@ -1,0 +1,88 @@
+import GoogleMaps
+import UIKit
+import XCTest
+
+@testable import NitroMaps
+
+final class GoogleMarkerVisualApplierTests: XCTestCase {
+  func testSameUncachedImageKeepsTheLaterAnchor() {
+    var completions: [(UIImage?) -> Void] = []
+    let applier = GoogleMarkerVisualApplier(
+      cachedImage: { _ in nil },
+      loadImage: { _, completion in completions.append(completion) }
+    )
+    let marker = GMSMarker()
+    let image = MarkerImage(
+      uri: "https://example.test/pin.png",
+      width: 40,
+      height: 40,
+      scale: 1
+    )
+
+    applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
+    applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 1, y: 1)), to: marker)
+
+    XCTAssertEqual(completions.count, 1)
+
+    completions[0](makeIcon())
+
+    XCTAssertEqual(marker.groundAnchor.x, 1, accuracy: 0.0001)
+    XCTAssertEqual(marker.groundAnchor.y, 1, accuracy: 0.0001)
+  }
+
+  func testAppliedImageIsNotReplacedByAStalePendingLoad() {
+    let iconA = makeIcon()
+    let iconB = makeIcon()
+    var completions: [(UIImage?) -> Void] = []
+    let imageA = MarkerImage(
+      uri: "https://example.test/a.png",
+      width: 40,
+      height: 40,
+      scale: 1
+    )
+    let imageB = MarkerImage(
+      uri: "https://example.test/b.png",
+      width: 40,
+      height: 40,
+      scale: 1
+    )
+    let applier = GoogleMarkerVisualApplier(
+      cachedImage: { image in image.uri.hasSuffix("a.png") ? iconA : nil },
+      loadImage: { _, completion in completions.append(completion) }
+    )
+    let marker = GMSMarker()
+
+    applier.apply(markerDescriptor(image: imageA, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
+    applier.apply(markerDescriptor(image: imageB, anchor: MarkerAnchor(x: 1, y: 1)), to: marker)
+    applier.apply(markerDescriptor(image: imageA, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
+
+    XCTAssertEqual(completions.count, 1)
+    completions[0](iconB)
+
+    XCTAssertTrue(marker.icon === iconA)
+    XCTAssertEqual(marker.groundAnchor.x, 0, accuracy: 0.0001)
+    XCTAssertEqual(marker.groundAnchor.y, 0, accuracy: 0.0001)
+  }
+}
+
+private func markerDescriptor(image: MarkerImage, anchor: MarkerAnchor) -> MarkerDescriptor {
+  MarkerDescriptor(
+    id: "marker",
+    coordinate: Coordinate(latitude: 0, longitude: 0),
+    title: nil,
+    subtitle: nil,
+    draggable: nil,
+    clusterable: nil,
+    image: image,
+    anchor: anchor,
+    centerOffset: nil,
+    rotation: nil,
+    flat: nil,
+    opacity: nil,
+    enteringAnimation: nil
+  )
+}
+
+private func makeIcon() -> UIImage {
+  UIGraphicsImageRenderer(size: CGSize(width: 40, height: 40)).image { _ in }
+}

--- a/package/iosTests/GoogleMarkerVisualApplierTests.swift
+++ b/package/iosTests/GoogleMarkerVisualApplierTests.swift
@@ -22,12 +22,17 @@ final class GoogleMarkerVisualApplierTests: XCTestCase {
     applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
     applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 1, y: 1)), to: marker)
 
-    XCTAssertEqual(completions.count, 1)
+    XCTAssertEqual(completions.count, 2)
 
-    let icon = makeIcon()
-    completions[0](icon)
+    let staleIcon = makeIcon()
+    let latestIcon = makeIcon()
+    completions[0](staleIcon)
 
-    XCTAssertTrue(marker.icon === icon)
+    XCTAssertNil(marker.icon)
+
+    completions[1](latestIcon)
+
+    XCTAssertTrue(marker.icon === latestIcon)
     XCTAssertEqual(marker.groundAnchor.x, 1, accuracy: 0.0001)
     XCTAssertEqual(marker.groundAnchor.y, 1, accuracy: 0.0001)
   }

--- a/package/iosTests/GoogleMarkerVisualApplierTests.swift
+++ b/package/iosTests/GoogleMarkerVisualApplierTests.swift
@@ -24,8 +24,10 @@ final class GoogleMarkerVisualApplierTests: XCTestCase {
 
     XCTAssertEqual(completions.count, 1)
 
-    completions[0](makeIcon())
+    let icon = makeIcon()
+    completions[0](icon)
 
+    XCTAssertTrue(marker.icon === icon)
     XCTAssertEqual(marker.groundAnchor.x, 1, accuracy: 0.0001)
     XCTAssertEqual(marker.groundAnchor.y, 1, accuracy: 0.0001)
   }

--- a/package/package.json
+++ b/package/package.json
@@ -32,7 +32,8 @@
     "react-native-better-maps.podspec",
     "!**/__tests__",
     "!**/__fixtures__",
-    "!**/__mocks__"
+    "!**/__mocks__",
+    "!android/src/test"
   ],
   "scripts": {
     "prebuild": "bun run nitrogen",

--- a/package/react-native-better-maps.podspec
+++ b/package/react-native-better-maps.podspec
@@ -33,4 +33,8 @@ Pod::Spec.new do |s|
   add_nitrogen_files(s)
 
   install_modules_dependencies(s)
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'iosTests/**/*.swift'
+  end
 end


### PR DESCRIPTION
## Summary
- include all displayed marker properties in viewport diff identity so retained markers refresh correctly
- apply image, anchor, center offset, rotation, flat mode, and opacity on Google Maps iOS without decoding local images on the main thread
- preserve configured marker opacity through Android entering animations and add focused Android unit coverage

## Test plan
- [x] `bun run typecheck`
- [x] `bun run --filter react-native-better-maps test --runInBand --ci --watchman=false`
- [x] `swiftc -parse` for all changed Swift files
- [ ] Run Android JUnit tests after adding a checked-in Gradle runner in a follow-up PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gmi-software/codesmith/react-native-better-maps/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789822301&installation_model_id=428715&pr_number=54&repository=gmi-software%2Freact-native-better-maps&return_to=https%3A%2F%2Fgithub.com%2Fgmi-software%2Freact-native-better-maps%2Fpull%2F54&signature=de7c878efed77c6fe5505dd90462ca23ee8da18f3ed13c0480052923f46cb9f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
