### PR TITLE
fix(ios): one pending load for Google marker visuals

### DIFF
--- a/package/ios/GoogleMarkerVisualApplier.swift
+++ b/package/ios/GoogleMarkerVisualApplier.swift
@@ -6,52 +6,98 @@ final class GoogleMarkerVisualApplier {
   private static let defaultIconToken: NSString = "__default__"
   private static let defaultPinImage = GMSMarker.markerImage(with: nil)
 
-  private let appliedTokens = NSMapTable<GMSMarker, NSString>.weakToStrongObjects()
-  private let pendingTokens = NSMapTable<GMSMarker, NSString>.weakToStrongObjects()
+  private struct PendingIconLoad {
+    let imageToken: NSString
+    var descriptor: MarkerDescriptor
+  }
+
+  private final class MarkerIconState: NSObject {
+    var appliedImageToken: NSString?
+    var loadGeneration = 0
+    var pending: PendingIconLoad?
+  }
+
+  private let states = NSMapTable<GMSMarker, MarkerIconState>.weakToStrongObjects()
+  private let cachedImage: (MarkerImage) -> UIImage?
+  private let loadImage: (MarkerImage, @escaping (UIImage?) -> Void) -> Void
+
+  init(
+    cachedImage: @escaping (MarkerImage) -> UIImage? = MarkerImageLoader.cachedImage(for:),
+    loadImage: @escaping (MarkerImage, @escaping (UIImage?) -> Void) -> Void = {
+      MarkerImageLoader.load($0, completion: $1)
+    }
+  ) {
+    self.cachedImage = cachedImage
+    self.loadImage = loadImage
+  }
 
   func apply(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
     marker.rotation = descriptor.rotation ?? 0
     marker.isFlat = descriptor.flat == true
     marker.opacity = Float(descriptor.opacity ?? 1)
+    applyAnchor(descriptor, to: marker)
     applyIcon(descriptor, to: marker)
   }
 
+  private func applyAnchor(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
+    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(
+      imageSize: anchorImageSize(descriptor, icon: marker.icon)
+    )
+  }
+
   private func applyIcon(_ descriptor: MarkerDescriptor, to marker: GMSMarker) {
+    let state = state(for: marker)
+
     guard let image = descriptor.image else {
-      pendingTokens.removeObject(forKey: marker)
-      if appliedTokens.object(forKey: marker) != Self.defaultIconToken {
+      cancelPending(state)
+      if state.appliedImageToken != Self.defaultIconToken {
         marker.icon = nil
-        appliedTokens.setObject(Self.defaultIconToken, forKey: marker)
+        state.appliedImageToken = Self.defaultIconToken
       }
-      marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(
-        imageSize: Self.defaultPinImage.size
-      )
       return
     }
 
-    let token = MarkerImageLoader.cacheKey(for: image)
-    if appliedTokens.object(forKey: marker) == token, let icon = marker.icon {
-      marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: icon.size)
+    let imageToken = MarkerImageLoader.cacheKey(for: image)
+    if state.appliedImageToken == imageToken, marker.icon != nil {
+      if state.pending != nil {
+        cancelPending(state)
+      }
       return
     }
 
-    if let cached = MarkerImageLoader.cachedImage(for: image) {
-      pendingTokens.removeObject(forKey: marker)
-      setIcon(cached, token: token, on: marker, descriptor: descriptor)
+    if var pending = state.pending, pending.imageToken == imageToken {
+      pending.descriptor = descriptor
+      state.pending = pending
       return
     }
 
-    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: .zero)
-    pendingTokens.setObject(token, forKey: marker)
-    MarkerImageLoader.load(image) { [weak self, weak marker] uiImage in
-      guard let self, let marker, self.pendingTokens.object(forKey: marker) == token else {
+    if let cached = cachedImage(image) {
+      cancelPending(state)
+      setIcon(cached, token: imageToken, on: marker, descriptor: descriptor, state: state)
+      return
+    }
+
+    cancelPending(state)
+    let generation = state.loadGeneration
+    state.pending = PendingIconLoad(imageToken: imageToken, descriptor: descriptor)
+    loadImage(image) { [weak self, weak marker] uiImage in
+      guard let self, let marker, let state = self.states.object(forKey: marker) else {
         return
       }
-      self.pendingTokens.removeObject(forKey: marker)
+      guard state.loadGeneration == generation, let pending = state.pending else {
+        return
+      }
+      state.pending = nil
       guard let uiImage else {
         return
       }
-      self.setIcon(uiImage, token: token, on: marker, descriptor: descriptor)
+      self.setIcon(
+        uiImage,
+        token: pending.imageToken,
+        on: marker,
+        descriptor: pending.descriptor,
+        state: state
+      )
     }
   }
 
@@ -59,10 +105,40 @@ final class GoogleMarkerVisualApplier {
     _ uiImage: UIImage,
     token: NSString,
     on marker: GMSMarker,
-    descriptor: MarkerDescriptor
+    descriptor: MarkerDescriptor,
+    state: MarkerIconState
   ) {
     marker.icon = uiImage
-    marker.groundAnchor = descriptor.effectiveGoogleMapsAnchor(imageSize: uiImage.size)
-    appliedTokens.setObject(token, forKey: marker)
+    applyAnchor(descriptor, to: marker)
+    state.appliedImageToken = token
+  }
+
+  private func state(for marker: GMSMarker) -> MarkerIconState {
+    if let existing = states.object(forKey: marker) {
+      return existing
+    }
+    let created = MarkerIconState()
+    states.setObject(created, forKey: marker)
+    return created
+  }
+
+  private func cancelPending(_ state: MarkerIconState) {
+    state.loadGeneration += 1
+    state.pending = nil
+  }
+
+  private func anchorImageSize(_ descriptor: MarkerDescriptor, icon: UIImage?) -> CGSize {
+    if let image = descriptor.image, let width = image.width, let height = image.height,
+       width > 0, height > 0
+    {
+      return CGSize(width: width, height: height)
+    }
+    if descriptor.image == nil {
+      return Self.defaultPinImage.size
+    }
+    if let icon, icon.size.width > 0, icon.size.height > 0 {
+      return icon.size
+    }
+    return Self.defaultPinImage.size
   }
 }

--- a/package/ios/GoogleMarkerVisualApplier.swift
+++ b/package/ios/GoogleMarkerVisualApplier.swift
@@ -7,13 +7,13 @@ final class GoogleMarkerVisualApplier {
   private static let defaultPinImage = GMSMarker.markerImage(with: nil)
 
   private struct PendingIconLoad {
+    let applicationToken: NSObject
     let imageToken: NSString
-    var descriptor: MarkerDescriptor
+    let descriptor: MarkerDescriptor
   }
 
   private final class MarkerIconState: NSObject {
     var appliedImageToken: NSString?
-    var loadGeneration = 0
     var pending: PendingIconLoad?
   }
 
@@ -65,12 +65,6 @@ final class GoogleMarkerVisualApplier {
       return
     }
 
-    if var pending = state.pending, pending.imageToken == imageToken {
-      pending.descriptor = descriptor
-      state.pending = pending
-      return
-    }
-
     if let cached = cachedImage(image) {
       cancelPending(state)
       setIcon(cached, token: imageToken, on: marker, descriptor: descriptor, state: state)
@@ -78,13 +72,19 @@ final class GoogleMarkerVisualApplier {
     }
 
     cancelPending(state)
-    let generation = state.loadGeneration
-    state.pending = PendingIconLoad(imageToken: imageToken, descriptor: descriptor)
+    let applicationToken = NSObject()
+    state.pending = PendingIconLoad(
+      applicationToken: applicationToken,
+      imageToken: imageToken,
+      descriptor: descriptor
+    )
     loadImage(image) { [weak self, weak marker] uiImage in
       guard let self, let marker, let state = self.states.object(forKey: marker) else {
         return
       }
-      guard state.loadGeneration == generation, let pending = state.pending else {
+      guard let pending = state.pending,
+            pending.applicationToken === applicationToken
+      else {
         return
       }
       state.pending = nil
@@ -123,7 +123,6 @@ final class GoogleMarkerVisualApplier {
   }
 
   private func cancelPending(_ state: MarkerIconState) {
-    state.loadGeneration += 1
     state.pending = nil
   }
 

--- a/package/iosTests/GoogleMarkerVisualApplierTests.swift
+++ b/package/iosTests/GoogleMarkerVisualApplierTests.swift
@@ -1,0 +1,88 @@
+import GoogleMaps
+import UIKit
+import XCTest
+
+@testable import NitroMaps
+
+final class GoogleMarkerVisualApplierTests: XCTestCase {
+  func testSameUncachedImageKeepsTheLaterAnchor() {
+    var completions: [(UIImage?) -> Void] = []
+    let applier = GoogleMarkerVisualApplier(
+      cachedImage: { _ in nil },
+      loadImage: { _, completion in completions.append(completion) }
+    )
+    let marker = GMSMarker()
+    let image = MarkerImage(
+      uri: "https://example.test/pin.png",
+      width: 40,
+      height: 40,
+      scale: 1
+    )
+
+    applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
+    applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 1, y: 1)), to: marker)
+
+    XCTAssertEqual(completions.count, 1)
+
+    completions[0](makeIcon())
+
+    XCTAssertEqual(marker.groundAnchor.x, 1, accuracy: 0.0001)
+    XCTAssertEqual(marker.groundAnchor.y, 1, accuracy: 0.0001)
+  }
+
+  func testAppliedImageIsNotReplacedByAStalePendingLoad() {
+    let iconA = makeIcon()
+    let iconB = makeIcon()
+    var completions: [(UIImage?) -> Void] = []
+    let imageA = MarkerImage(
+      uri: "https://example.test/a.png",
+      width: 40,
+      height: 40,
+      scale: 1
+    )
+    let imageB = MarkerImage(
+      uri: "https://example.test/b.png",
+      width: 40,
+      height: 40,
+      scale: 1
+    )
+    let applier = GoogleMarkerVisualApplier(
+      cachedImage: { image in image.uri.hasSuffix("a.png") ? iconA : nil },
+      loadImage: { _, completion in completions.append(completion) }
+    )
+    let marker = GMSMarker()
+
+    applier.apply(markerDescriptor(image: imageA, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
+    applier.apply(markerDescriptor(image: imageB, anchor: MarkerAnchor(x: 1, y: 1)), to: marker)
+    applier.apply(markerDescriptor(image: imageA, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
+
+    XCTAssertEqual(completions.count, 1)
+    completions[0](iconB)
+
+    XCTAssertTrue(marker.icon === iconA)
+    XCTAssertEqual(marker.groundAnchor.x, 0, accuracy: 0.0001)
+    XCTAssertEqual(marker.groundAnchor.y, 0, accuracy: 0.0001)
+  }
+}
+
+private func markerDescriptor(image: MarkerImage, anchor: MarkerAnchor) -> MarkerDescriptor {
+  MarkerDescriptor(
+    id: "marker",
+    coordinate: Coordinate(latitude: 0, longitude: 0),
+    title: nil,
+    subtitle: nil,
+    draggable: nil,
+    clusterable: nil,
+    image: image,
+    anchor: anchor,
+    centerOffset: nil,
+    rotation: nil,
+    flat: nil,
+    opacity: nil,
+    enteringAnimation: nil
+  )
+}
+
+private func makeIcon() -> UIImage {
+  UIGraphicsImageRenderer(size: CGSize(width: 40, height: 40)).image { _ in }
+}

--- a/package/iosTests/GoogleMarkerVisualApplierTests.swift
+++ b/package/iosTests/GoogleMarkerVisualApplierTests.swift
@@ -22,12 +22,17 @@ final class GoogleMarkerVisualApplierTests: XCTestCase {
     applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 0, y: 0)), to: marker)
     applier.apply(markerDescriptor(image: image, anchor: MarkerAnchor(x: 1, y: 1)), to: marker)
 
-    XCTAssertEqual(completions.count, 1)
+    XCTAssertEqual(completions.count, 2)
 
-    let icon = makeIcon()
-    completions[0](icon)
+    let staleIcon = makeIcon()
+    let latestIcon = makeIcon()
+    completions[0](staleIcon)
 
-    XCTAssertTrue(marker.icon === icon)
+    XCTAssertNil(marker.icon)
+
+    completions[1](latestIcon)
+
+    XCTAssertTrue(marker.icon === latestIcon)
     XCTAssertEqual(marker.groundAnchor.x, 1, accuracy: 0.0001)
     XCTAssertEqual(marker.groundAnchor.y, 1, accuracy: 0.0001)
   }

--- a/package/iosTests/GoogleMarkerVisualApplierTests.swift
+++ b/package/iosTests/GoogleMarkerVisualApplierTests.swift
@@ -24,8 +24,10 @@ final class GoogleMarkerVisualApplierTests: XCTestCase {
 
     XCTAssertEqual(completions.count, 1)
 
-    completions[0](makeIcon())
+    let icon = makeIcon()
+    completions[0](icon)
 
+    XCTAssertTrue(marker.icon === icon)
     XCTAssertEqual(marker.groundAnchor.x, 1, accuracy: 0.0001)
     XCTAssertEqual(marker.groundAnchor.y, 1, accuracy: 0.0001)
   }

--- a/package/react-native-better-maps.podspec
+++ b/package/react-native-better-maps.podspec
@@ -33,4 +33,8 @@ Pod::Spec.new do |s|
   add_nitrogen_files(s)
 
   install_modules_dependencies(s)
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'iosTests/**/*.swift'
+  end
 end


### PR DESCRIPTION
## Summary
- keep a single in-flight Google Maps iOS marker image load per marker, keyed by generation and the latest descriptor
- cancel a conflicting pending load when the marker already shows the requested image, so an A→B→A sequence cannot apply a stale icon
- apply rotation, flat, opacity, and anchor before icon work, using declared image size instead of a zero-size fallback

## Test plan
- [x] `xcodebuild test` scheme `react-native-better-maps-Unit-Tests` — both XCTest cases pass
- [x] Argent on iPhone 17 Pro: Custom markers on Apple MapKit shows bundled pins, star badge, faded pin, and offset pin
- [ ] Argent Google Maps iOS Custom markers — blocked here: example app has no `GoogleMapsIosApiKey`
- [ ] Confirm Custom markers on Google iOS with a host API key: custom images (not default red pins), later rotation/anchor updates, faded opacity

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gmi-software/codesmith/react-native-better-maps/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789826834&installation_model_id=428715&pr_number=55&repository=gmi-software%2Freact-native-better-maps&return_to=https%3A%2F%2Fgithub.com%2Fgmi-software%2Freact-native-better-maps%2Fpull%2F55&signature=1dc8c12377f143a7db92e89f89ef25f68475a099872fdf22c8b3900774e18859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->