### PR TITLE
fix(android): keep MapView alive when it leaves the window

### DIFF
--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
@@ -313,23 +313,26 @@ class GoogleMapProviderAdapter(
       syncMarkerPressHandlers()
     }
 
-  override fun fetchCamera(): Promise<Camera> {
-    val map = googleMap
-    if (map != null) {
-      return promiseOnMain { map.cameraPosition.toCamera() }
+  override fun fetchCamera(): Promise<Camera> = promiseOnMain {
+    googleMap?.cameraPosition?.toCamera() ?: fallbackCamera()
+  }
+
+  /** The camera the caller last asked for, used until the map itself can answer. */
+  private fun fallbackCamera(): Camera {
+    val camera = _camera
+    if (camera != null) {
+      return camera
     }
 
-    return Promise.resolved(
-      _camera ?: Camera(
-        center = Coordinate(
-          latitude = _region?.latitude ?: 0.0,
-          longitude = _region?.longitude ?: 0.0,
-        ),
-        zoom = 10.0,
-        heading = null,
-        pitch = null,
-        altitude = null,
+    return Camera(
+      center = Coordinate(
+        latitude = _region?.latitude ?: 0.0,
+        longitude = _region?.longitude ?: 0.0,
       ),
+      zoom = 10.0,
+      heading = null,
+      pitch = null,
+      altitude = null,
     )
   }
 
@@ -342,21 +345,8 @@ class GoogleMapProviderAdapter(
     updateMapCamera(camera, animated = true, durationMs = (animationDuration * 1000).toInt())
   }
 
-  override fun getVisibleRegion(): Promise<VisibleRegion> {
-    val map = googleMap
-    if (map != null) {
-      return promiseOnMain { map.projection.toNitroVisibleRegion() }
-    }
-
-    val zero = Coordinate(latitude = 0.0, longitude = 0.0)
-    return Promise.resolved(
-      VisibleRegion(
-        nearLeft = zero,
-        nearRight = zero,
-        farLeft = zero,
-        farRight = zero,
-      ),
-    )
+  override fun getVisibleRegion(): Promise<VisibleRegion> = promiseOnMain {
+    googleMap?.projection?.toNitroVisibleRegion() ?: emptyVisibleRegion()
   }
 
   override fun fitToCoordinates(
@@ -748,9 +738,9 @@ class GoogleMapProviderAdapter(
     onMapReady?.invoke()
   }
 
-  override fun prepareForRecycle() {
-    isUserGesture = false
-    hasFiredMapReady = false
+  override fun release() {
+    // Drop the JS callbacks first: a map event still in flight must not reach a
+    // view that is already gone.
     onRegionChange = null
     onRegionChangeComplete = null
     onMapReady = null
@@ -763,38 +753,8 @@ class GoogleMapProviderAdapter(
     onPolygonPress = null
     onCirclePress = null
     onClusterPress = null
-    _markers = null
-    _polylines = null
-    _polygons = null
-    _circles = null
-    pendingMarkers = null
-    pendingPolylines = null
-    pendingPolygons = null
-    pendingCircles = null
+
     overlayController.clear()
-    _mapType = MapType.STANDARD
-    _region = null
-    _camera = null
-    scrollEnabled = true
-    zoomEnabled = true
-    rotateEnabled = true
-    pitchEnabled = true
-    _showsUserLocation = null
-    _followsUserLocation = null
-    _showsCompass = null
-    _showsScale = null
-    _customMapStyle = null
-    _clusteringEnabled = null
-    _mapPadding = null
-    _markerEnteringAnimation = null
-    _clusterEnteringAnimation = null
-    overlayController.markerEnteringAnimation = null
-    overlayController.clusterEnteringAnimation = null
-    googleMap?.mapType = MapType.STANDARD.toGoogleMapType()
-    googleMap?.isMyLocationEnabled = false
-    googleMap?.setMapStyle(null)
-    googleMap?.setPadding(0, 0, 0, 0)
-    applyUiSettings()
     destroyMapView()
   }
 
@@ -816,3 +776,8 @@ class GoogleMapProviderAdapter(
 }
 
 private fun normalizeGoogleMapId(value: String?): String? = value?.trim()?.takeIf { it.isNotEmpty() }
+
+private fun emptyVisibleRegion(): VisibleRegion {
+  val zero = Coordinate(latitude = 0.0, longitude = 0.0)
+  return VisibleRegion(nearLeft = zero, nearRight = zero, farLeft = zero, farRight = zero)
+}

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/GoogleMapProviderAdapter.kt
@@ -1,7 +1,9 @@
 package com.margelo.nitro.nitromaps
 
 import android.Manifest
+import android.content.ComponentCallbacks
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Handler
 import android.os.Looper
 import android.view.View
@@ -32,7 +34,6 @@ class GoogleMapProviderAdapter(
   private var googleMap: GoogleMap? = null
   private var isUserGesture = false
   private var hasFiredMapReady = false
-  private var isDestroyed = false
   private val overlayController = MapOverlayController(null, context)
   private var pendingMarkers: Array<MarkerDescriptor>? = null
   private var pendingPolylines: Array<PolylineDescriptor>? = null
@@ -49,32 +50,46 @@ class GoogleMapProviderAdapter(
         mapId(mapId)
       }
     },
-  ).also { mapView ->
-    mapView.onCreate(null)
-    context.addLifecycleEventListener(this@GoogleMapProviderAdapter)
+  )
 
-    mapView.addOnAttachStateChangeListener(
-      object : View.OnAttachStateChangeListener {
-        override fun onViewAttachedToWindow(v: View) {
-          if (!isDestroyed) {
-            mapView.onResume()
-          }
-        }
+  private val lifecycle = MapViewLifecycleOwner(view)
 
-        override fun onViewDetachedFromWindow(v: View) {
-          context.removeLifecycleEventListener(this@GoogleMapProviderAdapter)
-          mapView.onPause()
-          destroyMapViewIfNeeded(mapView)
-        }
-      },
-    )
+  private var isAttachedToWindow = false
 
-    mapView.getMapAsync { map ->
+  /** React only mounts views while the host runs; [onHostPause] corrects this. */
+  private var isHostResumed = true
+
+  private val attachStateListener = object : View.OnAttachStateChangeListener {
+    override fun onViewAttachedToWindow(v: View) {
+      isAttachedToWindow = true
+      syncLifecycleState()
+    }
+
+    override fun onViewDetachedFromWindow(v: View) {
+      isAttachedToWindow = false
+      syncLifecycleState()
+    }
+  }
+
+  private val memoryCallbacks = object : ComponentCallbacks {
+    override fun onConfigurationChanged(newConfig: Configuration) = Unit
+
+    override fun onLowMemory() {
+      lifecycle.onLowMemory()
+    }
+  }
+
+  init {
+    context.addLifecycleEventListener(this)
+    context.registerComponentCallbacks(memoryCallbacks)
+    view.addOnAttachStateChangeListener(attachStateListener)
+
+    view.getMapAsync { map ->
       googleMap = map
       configureMap(map)
     }
 
-    installViewportSizeListener(mapView)
+    installViewportSizeListener(view)
   }
 
   private var _mapType = MapType.STANDARD
@@ -376,20 +391,31 @@ class GoogleMapProviderAdapter(
   }
 
   override fun onHostResume() {
-    if (!isDestroyed) {
-      view.onResume()
-    }
+    isHostResumed = true
+    syncLifecycleState()
   }
 
   override fun onHostPause() {
-    if (!isDestroyed) {
-      view.onPause()
-    }
+    isHostResumed = false
+    syncLifecycleState()
   }
 
   override fun onHostDestroy() {
-    context.removeLifecycleEventListener(this)
-    destroyMapViewIfNeeded(view)
+    destroyMapView()
+  }
+
+  /**
+   * Brings the map to the state implied by whether it is on screen and whether the
+   * host is in the foreground. Leaving the window stops the map, never destroys it.
+   */
+  private fun syncLifecycleState() {
+    val target = when {
+      !isAttachedToWindow -> MapViewLifecycleState.CREATED
+      isHostResumed -> MapViewLifecycleState.RESUMED
+      else -> MapViewLifecycleState.STARTED
+    }
+
+    lifecycle.moveTo(target)
   }
 
   private fun configureMap(map: GoogleMap) {
@@ -769,15 +795,23 @@ class GoogleMapProviderAdapter(
     googleMap?.setMapStyle(null)
     googleMap?.setPadding(0, 0, 0, 0)
     applyUiSettings()
+    destroyMapView()
   }
 
-  private fun destroyMapViewIfNeeded(mapView: MapView) {
-    if (isDestroyed) {
+  /**
+   * Tears the map down for good. Both call sites discard the adapter afterwards;
+   * detaching from the window deliberately does not come here.
+   */
+  private fun destroyMapView() {
+    if (lifecycle.isDestroyed) {
       return
     }
 
-    mapView.onDestroy()
-    isDestroyed = true
+    context.removeLifecycleEventListener(this)
+    context.unregisterComponentCallbacks(memoryCallbacks)
+    view.removeOnAttachStateChangeListener(attachStateListener)
+    lifecycle.moveTo(MapViewLifecycleState.DESTROYED)
+    googleMap = null
   }
 }
 

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/HybridMapView.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/HybridMapView.kt
@@ -356,7 +356,7 @@ class HybridMapView(private val context: ThemedReactContext) :
    * React Native has view recycling enabled.
    */
   private fun releaseAdapter() {
-    adapter?.prepareForRecycle()
+    adapter?.release()
     adapter?.view?.let(view::removeView)
     adapter = null
   }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/HybridMapView.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/HybridMapView.kt
@@ -8,12 +8,16 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.views.RecyclableView
 
+private const val MAP_VIEW_NOT_MOUNTED_MESSAGE = "MapView is not mounted"
+
 @Keep
 @DoNotStrip
 class HybridMapView(private val context: ThemedReactContext) :
   HybridMapViewSpec(),
   RecyclableView {
 
+  /** Written on the UI thread, read from the JS thread by the imperative methods. */
+  @Volatile
   private var adapter: MapProviderAdapter? = null
 
   private var _provider = MapProvider.GOOGLE
@@ -269,33 +273,44 @@ class HybridMapView(private val context: ThemedReactContext) :
       adapter?.onClusterPress = value
     }
 
-  override fun fetchCamera(): Promise<Camera> = currentAdapter().fetchCamera()
+  override fun fetchCamera(): Promise<Camera> {
+    val mounted = adapter ?: return notMountedRejection()
+    return mounted.fetchCamera()
+  }
 
   override fun applyCamera(camera: Camera): Promise<Unit> {
-    currentAdapter().applyCamera(camera)
+    val mounted = adapter ?: return notMountedRejection()
+    mounted.applyCamera(camera)
     return Promise.resolved(Unit)
   }
 
   override fun animateCamera(camera: Camera, duration: Double?): Promise<Unit> {
-    currentAdapter().animateCamera(camera, duration)
+    val mounted = adapter ?: return notMountedRejection()
+    mounted.animateCamera(camera, duration)
     return Promise.resolved(Unit)
   }
 
-  override fun getVisibleRegion(): Promise<VisibleRegion> = currentAdapter().getVisibleRegion()
+  override fun getVisibleRegion(): Promise<VisibleRegion> {
+    val mounted = adapter ?: return notMountedRejection()
+    return mounted.getVisibleRegion()
+  }
 
   override fun fitToCoordinates(
     coordinates: Array<Coordinate>,
     padding: EdgePadding?,
     animated: Boolean?,
   ): Promise<Unit> {
-    currentAdapter().fitToCoordinates(coordinates, padding, animated)
+    val mounted = adapter ?: return notMountedRejection()
+    mounted.fitToCoordinates(coordinates, padding, animated)
     return Promise.resolved(Unit)
   }
 
+  override fun onDropView() {
+    releaseAdapter()
+  }
+
   override fun prepareForRecycle() {
-    adapter?.prepareForRecycle()
-    adapter?.view?.let(view::removeView)
-    adapter = null
+    releaseAdapter()
     _provider = MapProvider.GOOGLE
     _mapType = MapType.STANDARD
     _region = null
@@ -332,18 +347,25 @@ class HybridMapView(private val context: ThemedReactContext) :
     onClusterPress = null
   }
 
-  private fun currentAdapter(): MapProviderAdapter {
-    adapter?.let { return it }
-    installAdapter(_provider)
-    return requireNotNull(adapter)
+  private fun <T> notMountedRejection(): Promise<T> =
+    Promise.rejected(IllegalStateException(MAP_VIEW_NOT_MOUNTED_MESSAGE))
+
+  /**
+   * Detaches and destroys the installed adapter. Both teardown paths land here:
+   * [onDropView] fires on every unmount, while [prepareForRecycle] only fires when
+   * React Native has view recycling enabled.
+   */
+  private fun releaseAdapter() {
+    adapter?.prepareForRecycle()
+    adapter?.view?.let(view::removeView)
+    adapter = null
   }
 
   private fun installAdapter(provider: MapProvider) {
+    // Built before the teardown so an unsupported provider leaves the current map intact.
     val nextAdapter = makeAdapter(provider)
-    val previousAdapter = adapter
 
-    previousAdapter?.prepareForRecycle()
-    previousAdapter?.view?.let(view::removeView)
+    releaseAdapter()
     adapter = nextAdapter
     attach(nextAdapter.view)
     syncState(nextAdapter)

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapProviderAdapter.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapProviderAdapter.kt
@@ -48,5 +48,10 @@ interface MapProviderAdapter {
   fun animateCamera(camera: Camera, duration: Double?)
   fun getVisibleRegion(): Promise<VisibleRegion>
   fun fitToCoordinates(coordinates: Array<Coordinate>, padding: EdgePadding?, animated: Boolean?)
+
+  /**
+   * Resets adapter state and releases the underlying native map. Every caller
+   * discards the adapter afterwards; leaving the window does not trigger it.
+   */
   fun prepareForRecycle()
 }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapProviderAdapter.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapProviderAdapter.kt
@@ -50,8 +50,10 @@ interface MapProviderAdapter {
   fun fitToCoordinates(coordinates: Array<Coordinate>, padding: EdgePadding?, animated: Boolean?)
 
   /**
-   * Resets adapter state and releases the underlying native map. Every caller
-   * discards the adapter afterwards; leaving the window does not trigger it.
+   * Destroys the underlying native map and unregisters everything the adapter owns.
+   * Every caller discards the adapter afterwards, so this is a one-way transition --
+   * it is not the Nitro `RecyclableView.prepareForRecycle` reset. Leaving the window
+   * does not trigger it; a detached map is only stopped.
    */
-  fun prepareForRecycle()
+  fun release()
 }

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapViewLifecycleOwner.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapViewLifecycleOwner.kt
@@ -1,0 +1,94 @@
+package com.margelo.nitro.nitromaps
+
+import com.google.android.gms.maps.MapView
+
+/**
+ * Drives a [MapView] through the lifecycle callbacks the Maps SDK requires.
+ *
+ * The SDK only tolerates ordered transitions, so [moveTo] walks one state at a time.
+ * Detaching never destroys the map — only an explicit move to
+ * [MapViewLifecycleState.DESTROYED] does — because a destroyed map cannot be resumed.
+ */
+internal class MapViewLifecycleOwner(private val mapView: MapView) {
+  private var state = MapViewLifecycleState.CREATED
+
+  val isDestroyed: Boolean
+    get() = state == MapViewLifecycleState.DESTROYED
+
+  init {
+    mapView.onCreate(null)
+  }
+
+  /** Moves the map to [target], emitting every intermediate callback along the way. */
+  fun moveTo(target: MapViewLifecycleState) {
+    if (isDestroyed) {
+      return
+    }
+
+    if (target == MapViewLifecycleState.DESTROYED) {
+      destroy()
+      return
+    }
+
+    while (state.ordinal < target.ordinal) {
+      stepUp()
+    }
+
+    while (state.ordinal > target.ordinal) {
+      stepDown()
+    }
+  }
+
+  fun onLowMemory() {
+    if (isDestroyed) {
+      return
+    }
+
+    mapView.onLowMemory()
+  }
+
+  private fun destroy() {
+    while (state.ordinal > MapViewLifecycleState.CREATED.ordinal) {
+      stepDown()
+    }
+
+    mapView.onDestroy()
+    state = MapViewLifecycleState.DESTROYED
+  }
+
+  private fun stepUp() {
+    when (state) {
+      MapViewLifecycleState.CREATED -> {
+        mapView.onStart()
+        state = MapViewLifecycleState.STARTED
+      }
+
+      MapViewLifecycleState.STARTED -> {
+        mapView.onResume()
+        state = MapViewLifecycleState.RESUMED
+      }
+
+      MapViewLifecycleState.RESUMED,
+      MapViewLifecycleState.DESTROYED,
+      -> Unit
+    }
+  }
+
+  private fun stepDown() {
+    when (state) {
+      MapViewLifecycleState.RESUMED -> {
+        mapView.onPause()
+        state = MapViewLifecycleState.STARTED
+      }
+
+      MapViewLifecycleState.STARTED -> {
+        mapView.onStop()
+        state = MapViewLifecycleState.CREATED
+      }
+
+      MapViewLifecycleState.CREATED,
+      MapViewLifecycleState.DESTROYED,
+      -> Unit
+    }
+  }
+}

--- a/package/android/src/main/java/com/margelo/nitro/nitromaps/MapViewLifecycleState.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitromaps/MapViewLifecycleState.kt
@@ -1,0 +1,12 @@
+package com.margelo.nitro.nitromaps
+
+/**
+ * Ordered lifecycle states a Google `MapView` can be driven through. [CREATED],
+ * [STARTED] and [RESUMED] are reversible; [DESTROYED] is terminal.
+ */
+internal enum class MapViewLifecycleState {
+  CREATED,
+  STARTED,
+  RESUMED,
+  DESTROYED,
+}


### PR DESCRIPTION
## Problem

Detaching the map from the window destroyed the underlying Google `MapView` and latched `isDestroyed` permanently, so it could never be resumed again:

```kotlin
override fun onViewDetachedFromWindow(v: View) {
  context.removeLifecycleEventListener(this@GoogleMapProviderAdapter)
  mapView.onPause()
  destroyMapViewIfNeeded(mapView)   // -> onDestroy(); isDestroyed = true, forever
}
```

Leaving the window is not the same as being thrown away. Any parent reparenting, `removeClippedSubviews`, or a navigator detaching an inactive screen (React Navigation does this by default) left a blank, dead map for the rest of the session. Unmount/remount was fine — a fresh adapter was built — so this only bit the detach-without-unmount paths.

Two further problems fell out of the same code:

- The lifecycle listener was unregistered on that first detach, so `onHostResume`/`onHostPause` stopped working even if the view came back.
- `onStart`, `onStop` and `onLowMemory` were never forwarded to the SDK at all — only `onCreate(null)`, `onResume`, `onPause` and `onDestroy`.

## Fix

The one-way latch becomes an ordered state machine (`MapViewLifecycleOwner`) that walks one step at a time, since the Maps SDK only tolerates ordered transitions. Every state below `DESTROYED` is reversible.

The target state is now derived from two independent signals instead of being a side effect of a view event:

```kotlin
!isAttachedToWindow -> CREATED     // off screen: pause + stop
isHostResumed       -> RESUMED
else                -> STARTED     // attached, app backgrounded
```

`onDestroy()` moves to `prepareForRecycle()` and `onHostDestroy()` — the two points where the adapter is genuinely discarded. That part matters: detach used to be the *only* disposal path, so removing `onDestroy()` from it without adding it there would have traded a dead map for leaked `MapView`s.

`onSaveInstanceState` is intentionally not forwarded. A Fabric view has no host to hand it a `Bundle` and no restore path, so it would be dead code.

## Verification

Compile-checked (`:react-native-better-maps:compileDebugKotlin`, no warnings), then A/B tested on an emulator: the map inside a `ScrollView` with `removeClippedSubviews`, scrolled out of view and back, with the SDK lifecycle calls logged.

| | before | after |
|---|---|---|
| start | `onCreate → onResume` | `onCreate → onStart → onResume` |
| detach | `onPause → onDestroy` | `onPause → onStop` |
| re-attach | *nothing* | `onStart → onResume` |
| result | blank rectangle, Google logo only | map fully alive |

Before the fix, re-attach logged nothing at all — the latch blocked the resume, exactly as diagnosed.

Only the `removeClippedSubviews` path was exercised on device; screens and reparenting go through the same `onViewDetachedFromWindow`, but were not run separately. `onLowMemory` was not exercised under real memory pressure.

## Notes

Android only — iOS never had this, and it needs no equivalent change. No public API change: no new props, no type changes, nothing for consumers to migrate.

No regression test: the Android module has no test infrastructure (no `src/test`, no JUnit dependency), and `MapViewLifecycleOwner` depends on `MapView`, so covering it means pulling in Robolectric or mockito. Worth deciding separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gmi-software/codesmith/react-native-better-maps/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790195045&installation_model_id=428715&pr_number=56&repository=gmi-software%2Freact-native-better-maps&return_to=https%3A%2F%2Fgithub.com%2Fgmi-software%2Freact-native-better-maps%2Fpull%2F56&signature=dc2fcb93f10d78610420f7895d72cb599ffa6f153d1b8ba20b6259a91f2f5c96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->