### PR TITLE
refactor: remove dead normalizeMarkerDescriptor helper

### DIFF
--- a/package/src/utils/enteringAnimation.ts
+++ b/package/src/utils/enteringAnimation.ts
@@ -1,11 +1,5 @@
-import type {
-  MarkerDescriptor as PublicMarkerDescriptor,
-  OverlayEnteringAnimation,
-} from '../types/overlays';
-import type {
-  MarkerDescriptor,
-  OverlayEnteringAnimationDescriptor,
-} from '../native/specs/overlays';
+import type { OverlayEnteringAnimation } from '../types/overlays';
+import type { OverlayEnteringAnimationDescriptor } from '../native/specs/overlays';
 
 export function normalizeEnteringAnimation(
   animation: OverlayEnteringAnimation | undefined,
@@ -27,19 +21,5 @@ export function normalizeEnteringAnimation(
     duration: animation.duration,
     delay: animation.delay,
     reduceMotion: animation.reduceMotion,
-  };
-}
-
-export function normalizeMarkerDescriptor(
-  marker: PublicMarkerDescriptor,
-): MarkerDescriptor {
-  return {
-    id: marker.id,
-    coordinate: marker.coordinate,
-    title: marker.title,
-    subtitle: marker.subtitle,
-    draggable: marker.draggable,
-    clusterable: marker.clusterable,
-    enteringAnimation: normalizeEnteringAnimation(marker.enteringAnimation),
   };
 }


### PR DESCRIPTION
## What

Deletes `normalizeMarkerDescriptor` (singular) from `package/src/utils/enteringAnimation.ts`, along with the `MarkerDescriptor` / `PublicMarkerDescriptor` type imports it was the only user of in that file.

## Why

It was dead code, and it was also wrong:

- **No callers.** A repo-wide grep for `normalizeMarkerDescriptor\b` matched only its own definition — nothing in `package/src`, `package/type-tests` or `example` — and it was not re-exported from `package/src/index.ts`.
- **Wrong if it had ever been called.** It duplicated `normalizeDescriptor` in `package/src/overlays/normalizeMarkerDescriptors.ts` but dropped `image`, `anchor`, `centerOffset`, `rotation`, `flat` and `opacity`. Any future caller would have silently lost those marker properties.

`normalizeEnteringAnimation` in the same file stays — it is still used by `normalizeMarkerDescriptors.ts`, which is the complete and correct implementation.

## Verification

No behaviour change: nothing referenced the deleted symbol before or after.

| Check | Result |
| --- | --- |
| `bun run lint` | pass |
| `bun run typecheck` | pass |
| `cd package && bun test src/` | 50 pass, 0 fail |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gmi-software/codesmith/react-native-better-maps/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790203451&installation_model_id=428715&pr_number=57&repository=gmi-software%2Freact-native-better-maps&return_to=https%3A%2F%2Fgithub.com%2Fgmi-software%2Freact-native-better-maps%2Fpull%2F57&signature=ae4b5485c9e128b5995a00566b0c5f2568d08fe82d93a526b037971b59e3a70d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->