### PR TITLE
chore: remove unused hooks barrel

### DIFF
--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -1,1 +1,0 @@
-export { useCollectedOverlays } from './useCollectedOverlays';


### PR DESCRIPTION
## Summary

Deletes `package/src/hooks/index.ts`, a one-line barrel re-exporting `useCollectedOverlays` that nothing imported.

## Why it is safe

- No importers: `from '../hooks'` / `from './hooks'` has no matches anywhere in `package/src` or `example`.
- The only consumer, `package/src/components/MapView.tsx:3`, imports the hook by path — the established pattern in this package.
- `useCollectedOverlays` is internal. `package/src/index.ts` exports only components, types and utils, so the public API surface is unchanged.
- The other three barrels (`components`, `types`, `utils`) *are* consumed by `src/index.ts`; the hooks barrel was the only unused one, so this does not cut against a package-wide convention.

## Verification

| Check | Result |
| --- | --- |
| `bun run lint` | clean |
| `bun run typecheck` | exit 0 |
| `bun run build` | exit 0, 29 files compiled |
| `cd package && bun test src/` | 50 pass, 0 fail |
| `bun run doctor` | `deslop/unused-file` gone |

`bun run doctor` still exits 1, as it did before this change — the repo carries pre-existing findings it does not gate on. To confirm nothing regressed I ran doctor both ways: baseline was **8** issues, now **7**. The one that disappeared is exactly `deslop/unused-file` on `src/hooks/index.ts`; the remaining 7 are unchanged and out of scope here:

- `deslop/unused-dev-dependency` — `package.json`
- `no-ref-current-in-render` — `src/hooks/useCollectedOverlays.ts:239`
- `deslop/unused-export` — `src/utils/enteringAnimation.ts:33`
- 4 findings in `example/App.tsx`

No formatting run was needed — the change is a pure deletion, so no file was modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gmi-software/codesmith/react-native-better-maps/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790204513&installation_model_id=428715&pr_number=59&repository=gmi-software%2Freact-native-better-maps&return_to=https%3A%2F%2Fgithub.com%2Fgmi-software%2Freact-native-better-maps%2Fpull%2F59&signature=86bc4971b02a27d02fbd45d4c9bbedd7b4177f60f9f04564a2e3ed7c32d1f673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->