### PR TITLE
fix: resolve HybridView config via react-native package exports

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ React callbacks (onPress, onRegionChange, etc.)
 
 - **Source**: TypeScript in `package/src/`
 - **Build**: `react-native-builder-bob` (ESM-only, `module` + `typescript` targets)
-- **Metro**: Resolves `source` export condition for development
+- **Metro**: Resolves the `react-native` export condition to `src/` (Nitro HybridView pattern)
 - **Codegen**: Nitrogen reads `*.nitro.ts` specs and generates native bindings
 
 ## Technology choices

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -16,7 +16,6 @@ config.resolver.nodeModulesPaths = [
 config.resolver.unstable_enablePackageExports = true;
 config.resolver.unstable_conditionNames = [
   'react-native',
-  'source',
   'import',
   'require',
   'default',

--- a/package/package.json
+++ b/package/package.json
@@ -5,10 +5,12 @@
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/index.d.ts",
   "source": "./src/index.ts",
+  "react-native": "./src/index.ts",
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "react-native": "./src/index.ts",
       "types": "./lib/typescript/index.d.ts",
+      "import": "./lib/module/index.js",
       "default": "./lib/module/index.js"
     },
     "./app.plugin.js": "./app.plugin.js",


### PR DESCRIPTION
## Summary
- Add `react-native` entry and `exports.react-native` so Metro resolves `src/` instead of `lib/module/` for HybridView imports
- Keep Nitrogen `MapViewConfig.json` import path as documented (`../../nitrogen/...` from `src/native/`)
- Align example Metro conditions with the standard `react-native` export condition

## Why
Bob emits `MapViewNative` under `lib/module/native/`, so `../../nitrogen/...` resolves to `lib/nitrogen/` and breaks for consumers loading the compiled package. Resolving `src/` matches the Nitro HybridView packaging pattern used by nitro-image and Vision Camera.

## Test plan
- [x] `bun run typecheck`
- [ ] Install from this branch in an Expo app without a `MapViewConfig.json` metro `resolveRequest` hack and confirm the app bundles
- [ ] Example app still bundles with updated `example/metro.config.js`